### PR TITLE
Refactor: Social media accounts page — modal flow + grouped DataTable

### DIFF
--- a/apps/dashboard/src/components/ui/Table.tsx
+++ b/apps/dashboard/src/components/ui/Table.tsx
@@ -1,6 +1,20 @@
 import { CaretDownIcon, CaretUpIcon, CaretUpDownIcon } from "@phosphor-icons/react";
 import type { HTMLAttributes, ReactNode, TdHTMLAttributes, ThHTMLAttributes } from "react";
-import { useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
+
+// ─── Group type ───────────────────────────────────────────────────────────────
+
+/**
+ * Describes a named group of rows for use with the `groups` prop of `DataTable`.
+ *
+ * @typeParam T - Row object shape.
+ */
+export interface DataTableGroup<T> {
+  id: string;
+  /** Rendered as a single-cell row spanning all columns above the group's rows. */
+  header: ReactNode;
+  rows: T[];
+}
 
 // ─── Primitives ───────────────────────────────────────────────────────────────
 
@@ -65,7 +79,9 @@ export interface SortState {
 
 interface DataTableProps<T> {
   columns: ColumnDef<T>[];
-  data: T[];
+  data?: T[];
+  /** When provided, rows are rendered in named groups with a section-header row before each group. `data` is ignored. */
+  groups?: DataTableGroup<T>[];
   getRowKey: (row: T) => string | number;
   getRowClassName?: (row: T) => string;
   /** Keeps the header visible while scrolling. Requires the app header height as top offset. */
@@ -91,7 +107,8 @@ interface DataTableProps<T> {
  */
 export function DataTable<T>({
   columns,
-  data,
+  data = [],
+  groups,
   getRowKey,
   getRowClassName,
   stickyHeader = false,
@@ -126,25 +143,34 @@ export function DataTable<T>({
     onSortChange?.(nextSort);
   }
 
+  function sortRows(rows: T[]): T[] {
+    if (!sort) return rows;
+    const col = columns.find((c) => c.id === sort.id);
+    if (!col?.sortKey) return rows;
+    return [...rows].sort((a, b) => {
+      // biome-ignore lint/style/noNonNullAssertion: col is confirmed to have sortKey above
+      const av = col.sortKey!(a);
+      // biome-ignore lint/style/noNonNullAssertion: col is confirmed to have sortKey above
+      const bv = col.sortKey!(b);
+      const cmp =
+        typeof av === "number" && typeof bv === "number"
+          ? av - bv
+          : String(av).localeCompare(String(bv), "de", {
+              numeric: true,
+              sensitivity: "base",
+            });
+      return sort.dir === "asc" ? cmp : -cmp;
+    });
+  }
+
   const sorted = useMemo(
-    () =>
-      sort
-        ? [...data].sort((a, b) => {
-            const col = columns.find((c) => c.id === sort.id);
-            if (!col?.sortKey) return 0;
-            const av = col.sortKey(a);
-            const bv = col.sortKey(b);
-            const cmp =
-              typeof av === "number" && typeof bv === "number"
-                ? av - bv
-                : String(av).localeCompare(String(bv), "de", {
-                    numeric: true,
-                    sensitivity: "base",
-                  });
-            return sort.dir === "asc" ? cmp : -cmp;
-          })
-        : data,
+    () => sortRows(data),
     [allowUnsorted, data, sort, columns],
+  );
+
+  const sortedGroups = useMemo(
+    () => groups?.map((g) => ({ ...g, rows: sortRows(g.rows) })),
+    [allowUnsorted, groups, sort, columns],
   );
 
   return (
@@ -192,18 +218,51 @@ export function DataTable<T>({
         </TableRow>
       </TableHead>
       <TableBody>
-        {sorted.map((row, index) => (
-          <TableRow
-            key={getRowKey(row)}
-            className={`${index % 2 === 1 ? "bg-[var(--ds-row-stripe)]" : ""} ${getRowClassName?.(row) ?? ""}`}
-          >
-            {columns.map((col) => (
-              <Td key={col.id} className={col.cellClassName ?? col.className ?? ""}>
-                {col.cell(row)}
-              </Td>
+        {sortedGroups
+          ? (() => {
+              let stripeIndex = 0;
+              return sortedGroups.map((group) => (
+                <React.Fragment key={group.id}>
+                  <tr
+                    className="bg-[var(--ds-surface-inset)] hover:bg-transparent"
+                  >
+                    <td
+                      colSpan={columns.length}
+                      className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--ds-text-muted)]"
+                    >
+                      {group.header}
+                    </td>
+                  </tr>
+                  {group.rows.map((row) => {
+                    const idx = stripeIndex++;
+                    return (
+                      <TableRow
+                        key={getRowKey(row)}
+                        className={`${idx % 2 === 1 ? "bg-[var(--ds-row-stripe)]" : ""} ${getRowClassName?.(row) ?? ""}`}
+                      >
+                        {columns.map((col) => (
+                          <Td key={col.id} className={col.cellClassName ?? col.className ?? ""}>
+                            {col.cell(row)}
+                          </Td>
+                        ))}
+                      </TableRow>
+                    );
+                  })}
+                </React.Fragment>
+              ));
+            })()
+          : sorted.map((row, index) => (
+              <TableRow
+                key={getRowKey(row)}
+                className={`${index % 2 === 1 ? "bg-[var(--ds-row-stripe)]" : ""} ${getRowClassName?.(row) ?? ""}`}
+              >
+                {columns.map((col) => (
+                  <Td key={col.id} className={col.cellClassName ?? col.className ?? ""}>
+                    {col.cell(row)}
+                  </Td>
+                ))}
+              </TableRow>
             ))}
-          </TableRow>
-        ))}
       </TableBody>
     </Table>
   );

--- a/apps/dashboard/src/features/social/AccountFormDialog.tsx
+++ b/apps/dashboard/src/features/social/AccountFormDialog.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 
 import type { MastodonAccount } from "@lmaa/contracts";
 import type { ApiRequestError } from "@lmaa/shared";
-import { PLATFORM_MAP } from "@lmaa/ui";
+import { PLATFORM_MAP, ToggleSwitch } from "@lmaa/ui";
 
 import {
   Dialog,
@@ -159,7 +159,7 @@ export function AccountFormDialog({ target, onClose }: AccountFormDialogProps): 
 
   if (isCreate && !pickedService) {
     return (
-      <Dialog open title={dialogTitle} titleIcon={dialogIcon} onClose={onClose} maxWidth="md">
+      <Dialog open title={dialogTitle} titleIcon={dialogIcon} onClose={onClose} maxWidth="lg">
         <div className="px-6 py-4 space-y-3">
           <p className="text-xs font-semibold uppercase tracking-wide text-[var(--ds-text-muted)]">
             {t.pickService}
@@ -195,9 +195,9 @@ export function AccountFormDialog({ target, onClose }: AccountFormDialogProps): 
   // ─── Stage B — service form ───────────────────────────────────────────────
 
   return (
-    <Dialog open title={dialogTitle} titleIcon={dialogIcon} onClose={onClose} maxWidth="md">
-      {isCreate && (
-        <div className="px-6 pt-3">
+    <Dialog open title={dialogTitle} titleIcon={dialogIcon} onClose={onClose} maxWidth="lg">
+      <div className="flex items-center gap-3 px-6 pt-3">
+        {isCreate && (
           <button
             type="button"
             onClick={handleBack}
@@ -206,8 +206,15 @@ export function AccountFormDialog({ target, onClose }: AccountFormDialogProps): 
             <ArrowLeftIcon weight="bold" className="w-3 h-3" />
             {t.changeService}
           </button>
-        </div>
-      )}
+        )}
+        <label className="ml-auto inline-flex items-center gap-2 text-xs text-[var(--ds-text-muted)]">
+          <span>{t.fields.active}</span>
+          <ToggleSwitch
+            checked={form.isActive}
+            onChange={(isActive) => setForm({ ...form, isActive })}
+          />
+        </label>
+      </div>
       <div className="px-6 py-4">
         <MastodonAccountForm
           form={form}

--- a/apps/dashboard/src/features/social/AccountFormDialog.tsx
+++ b/apps/dashboard/src/features/social/AccountFormDialog.tsx
@@ -1,0 +1,239 @@
+import { ArrowLeftIcon } from "@phosphor-icons/react";
+import type React from "react";
+import { useState } from "react";
+
+import type { MastodonAccount } from "@lmaa/contracts";
+import type { ApiRequestError } from "@lmaa/shared";
+import { PLATFORM_MAP } from "@lmaa/ui";
+
+import {
+  Dialog,
+  dialogBtnPrimary,
+  dialogBtnSecondary,
+} from "@/components/ui/Dialog.tsx";
+import { useI18n } from "@/context/I18nContext.tsx";
+import { MastodonAccountForm } from "@/features/social/forms/MastodonAccountForm.tsx";
+import {
+  type MastodonAccountFormInput,
+  useCreateMastodonAccount,
+  useUpdateMastodonAccount,
+} from "@/features/social/hooks/useMastodonAccounts.ts";
+import {
+  type ServiceId,
+  SUPPORTED_PLATFORMS,
+} from "@/features/social/services.ts";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type DialogMode =
+  | { mode: "create" }
+  | { mode: "edit"; account: MastodonAccount };
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function emptyForm(): MastodonAccountFormInput {
+  return {
+    label: "",
+    instanceUrl: "",
+    username: "",
+    accessToken: "",
+    visibility: "public",
+    isActive: true,
+  };
+}
+
+function formFromAccount(account: MastodonAccount): MastodonAccountFormInput {
+  return {
+    label: account.label,
+    instanceUrl: account.instanceUrl,
+    username: account.username ?? "",
+    accessToken: "",
+    visibility: account.visibility,
+    isActive: account.isActive,
+  };
+}
+
+// ─── Props ───────────────────────────────────────────────────────────────────
+
+interface AccountFormDialogProps {
+  target: DialogMode;
+  onClose: () => void;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+/**
+ * Unified create/edit dialog for social media accounts.
+ *
+ * Create mode: Stage A shows a service-card picker; clicking a card advances
+ * to Stage B (the service form). A back link returns to Stage A.
+ *
+ * Edit mode: opens directly on Stage B (service inferred as Mastodon until
+ * multi-service support is added).
+ */
+export function AccountFormDialog({ target, onClose }: AccountFormDialogProps): React.ReactElement {
+  const { messages } = useI18n();
+  const t = messages.socialMedia;
+  const common = messages.common;
+
+  const isCreate = target.mode === "create";
+
+  // In edit mode we go straight to the form — no picker stage.
+  const [pickedService, setPickedService] = useState<ServiceId | null>(
+    isCreate ? null : "mastodon",
+  );
+
+  const [form, setForm] = useState<MastodonAccountFormInput>(
+    isCreate ? emptyForm() : formFromAccount((target as { mode: "edit"; account: MastodonAccount }).account),
+  );
+
+  const [error, setError] = useState<string | null>(null);
+
+  const createAccount = useCreateMastodonAccount();
+  const updateAccount = useUpdateMastodonAccount();
+
+  const isSaving = createAccount.isPending || updateAccount.isPending;
+
+  function handleBack(): void {
+    setPickedService(null);
+    setError(null);
+    setForm(emptyForm());
+  }
+
+  function mapError(err: unknown): string {
+    const apiErr = err as ApiRequestError;
+    if (apiErr.status === 400) return t.tokenInvalid;
+    if (apiErr.status === 503) return t.instanceUnreachable;
+    return t.saveError;
+  }
+
+  function handleSave(): void {
+    setError(null);
+
+    if (isCreate) {
+      if (!form.accessToken?.trim()) {
+        setError(t.tokenRequired);
+        return;
+      }
+      createAccount.mutate(
+        { ...form, accessToken: form.accessToken.trim() },
+        {
+          onSuccess: () => onClose(),
+          onError: (err) => setError(mapError(err)),
+        },
+      );
+    } else {
+      const editTarget = (target as { mode: "edit"; account: MastodonAccount }).account;
+      updateAccount.mutate(
+        {
+          id: editTarget.id,
+          input: {
+            ...form,
+            accessToken: form.accessToken?.trim() || undefined,
+          },
+        },
+        {
+          onSuccess: () => onClose(),
+          onError: (err) => setError(mapError(err)),
+        },
+      );
+    }
+  }
+
+  // ─── Dialog title / icon ──────────────────────────────────────────────────
+
+  const dialogTitle = (() => {
+    if (!isCreate) return t.editAccount;
+    if (!pickedService) return t.addAccountTitle;
+    return t.addMastodonAccount;
+  })();
+
+  const activePlatform = pickedService ? PLATFORM_MAP.get(pickedService) : undefined;
+  const dialogIcon = activePlatform ? (
+    <span className="shrink-0 text-[var(--ds-text-muted)]">
+      <activePlatform.icon size={24} />
+    </span>
+  ) : undefined;
+
+  // ─── Stage A — service picker ─────────────────────────────────────────────
+
+  if (isCreate && !pickedService) {
+    return (
+      <Dialog open title={dialogTitle} titleIcon={dialogIcon} onClose={onClose} maxWidth="md">
+        <div className="px-6 py-4 space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-[var(--ds-text-muted)]">
+            {t.pickService}
+          </p>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3">
+            {SUPPORTED_PLATFORMS.map((platform) => {
+              const Icon = platform.icon;
+              return (
+                <button
+                  key={platform.key}
+                  type="button"
+                  onClick={() => setPickedService(platform.key as ServiceId)}
+                  className="border border-[var(--ds-border-subtle)] rounded-card bg-[var(--ds-surface)] p-6 flex flex-col items-center gap-3 hover:border-[var(--ds-border-strong)] hover:bg-[var(--ds-surface-hover)] transition-colors"
+                >
+                  <Icon size={32} />
+                  <span className="text-sm font-medium text-[var(--ds-text)]">
+                    {platform.label}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+        <Dialog.Footer>
+          <button type="button" onClick={onClose} className={dialogBtnSecondary}>
+            {common.cancel}
+          </button>
+        </Dialog.Footer>
+      </Dialog>
+    );
+  }
+
+  // ─── Stage B — service form ───────────────────────────────────────────────
+
+  return (
+    <Dialog open title={dialogTitle} titleIcon={dialogIcon} onClose={onClose} maxWidth="md">
+      {isCreate && (
+        <div className="px-6 pt-3">
+          <button
+            type="button"
+            onClick={handleBack}
+            className="inline-flex items-center gap-1.5 text-xs text-[var(--ds-text-muted)] hover:text-[var(--ds-text)] transition-colors"
+          >
+            <ArrowLeftIcon weight="bold" className="w-3 h-3" />
+            {t.changeService}
+          </button>
+        </div>
+      )}
+      <div className="px-6 py-4">
+        <MastodonAccountForm
+          form={form}
+          onChange={setForm}
+          visibilityLabels={t.visibility}
+          labels={t.fields}
+          tokenPlaceholder={isCreate ? t.accessTokenPlaceholder : t.keepTokenPlaceholder}
+          requireToken={isCreate}
+        />
+      </div>
+      <Dialog.Footer>
+        {error && (
+          <p className="mr-auto text-xs text-red-500">{error}</p>
+        )}
+        <button type="button" onClick={onClose} className={dialogBtnSecondary}>
+          {common.cancel}
+        </button>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={isSaving}
+          className={dialogBtnPrimary}
+        >
+          {isSaving ? common.saving : common.save}
+        </button>
+      </Dialog.Footer>
+    </Dialog>
+  );
+}

--- a/apps/dashboard/src/features/social/SocialMediaAccountsPage.tsx
+++ b/apps/dashboard/src/features/social/SocialMediaAccountsPage.tsx
@@ -1,15 +1,9 @@
-import {
-  CheckCircleIcon,
-  MastodonLogoIcon,
-  PlusCircleIcon,
-  TrashIcon,
-  XCircleIcon,
-} from "@phosphor-icons/react";
-import { useState } from "react";
+import { MastodonLogoIcon, PencilSimpleIcon, PlusCircleIcon, TrashIcon } from "@phosphor-icons/react";
+import type React from "react";
+import { useMemo, useState } from "react";
 
-import type { MastodonAccount, MastodonVisibility } from "@lmaa/contracts";
-import type { ApiRequestError } from "@lmaa/shared";
-import { DashboardSection, ToggleSwitch } from "@lmaa/ui";
+import type { MastodonAccount } from "@lmaa/contracts";
+import { PLATFORM_MAP, ToggleSwitch } from "@lmaa/ui";
 
 import { ContentUnavailableView } from "@/components/ui/ContentUnavailableView.tsx";
 import {
@@ -20,265 +14,156 @@ import {
 } from "@/components/ui/Dialog.tsx";
 import { PageHeader } from "@/components/ui/PageHeader.tsx";
 import { PageBody, PageLayout } from "@/components/ui/PageLayout.tsx";
+import { type DataTableGroup, type ColumnDef, DataTable } from "@/components/ui/Table.tsx";
+import { TableActionButton } from "@/components/ui/TableActionButton.tsx";
 import { useI18n } from "@/context/I18nContext.tsx";
+import { AccountFormDialog } from "@/features/social/AccountFormDialog.tsx";
 import {
-  type MastodonAccountFormInput,
-  useCreateMastodonAccount,
   useDeleteMastodonAccount,
   useMastodonAccounts,
   useUpdateMastodonAccount,
 } from "@/features/social/hooks/useMastodonAccounts.ts";
 
-const inputClass =
-  "w-full h-9 px-3 rounded-control border border-[var(--ds-border)] bg-[var(--ds-input-bg)] text-sm text-[var(--ds-text)] placeholder:text-[var(--ds-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]";
-const selectClass =
-  "w-full h-9 px-3 rounded-control border border-[var(--ds-border)] bg-[var(--ds-input-bg)] text-sm text-[var(--ds-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]";
+// ─── Dialog state ─────────────────────────────────────────────────────────────
 
-const VISIBILITY_OPTIONS: MastodonVisibility[] = ["public", "unlisted", "private", "direct"];
+type DialogTarget =
+  | { mode: "create" }
+  | { mode: "edit"; account: MastodonAccount };
 
-function emptyForm(): MastodonAccountFormInput {
-  return {
-    label: "",
-    instanceUrl: "",
-    username: "",
-    accessToken: "",
-    visibility: "public",
-    isActive: true,
-  };
-}
+// ─── Component ───────────────────────────────────────────────────────────────
 
-function formFromAccount(account: MastodonAccount): MastodonAccountFormInput {
-  return {
-    label: account.label,
-    instanceUrl: account.instanceUrl,
-    username: account.username ?? "",
-    accessToken: "",
-    visibility: account.visibility,
-    isActive: account.isActive,
-  };
-}
-
-interface AccountFormProps {
-  form: MastodonAccountFormInput;
-  onChange: (form: MastodonAccountFormInput) => void;
-  visibilityLabels: Record<MastodonVisibility, string>;
-  labels: {
-    label: string;
-    instanceUrl: string;
-    username: string;
-    accessToken: string;
-    accessTokenOptional: string;
-    visibility: string;
-    active: string;
-  };
-  tokenPlaceholder: string;
-  requireToken: boolean;
-  showActiveField?: boolean;
-}
-
-function AccountForm({
-  form,
-  onChange,
-  visibilityLabels,
-  labels,
-  tokenPlaceholder,
-  requireToken,
-  showActiveField = true,
-}: AccountFormProps) {
-  return (
-    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-      <label className="space-y-1">
-        <span className="text-xs font-medium text-[var(--ds-text-muted)]">{labels.label}</span>
-        <input
-          value={form.label}
-          onChange={(event) => onChange({ ...form, label: event.target.value })}
-          className={inputClass}
-          placeholder="lmaa.space"
-        />
-      </label>
-      <label className="space-y-1">
-        <span className="text-xs font-medium text-[var(--ds-text-muted)]">
-          {labels.instanceUrl}
-        </span>
-        <input
-          value={form.instanceUrl}
-          onChange={(event) => onChange({ ...form, instanceUrl: event.target.value })}
-          className={inputClass}
-          placeholder="https://mastodon.social"
-        />
-      </label>
-      <label className="space-y-1">
-        <span className="text-xs font-medium text-[var(--ds-text-muted)]">{labels.username}</span>
-        <input
-          value={form.username ?? ""}
-          onChange={(event) => onChange({ ...form, username: event.target.value })}
-          className={inputClass}
-          placeholder="@lmaa"
-        />
-      </label>
-      <label className="space-y-1">
-        <span className="text-xs font-medium text-[var(--ds-text-muted)]">
-          {requireToken ? labels.accessToken : labels.accessTokenOptional}
-        </span>
-        <input
-          type="password"
-          value={form.accessToken ?? ""}
-          onChange={(event) => onChange({ ...form, accessToken: event.target.value })}
-          className={inputClass}
-          placeholder={tokenPlaceholder}
-          autoComplete="new-password"
-        />
-      </label>
-      <label className="space-y-1">
-        <span className="text-xs font-medium text-[var(--ds-text-muted)]">{labels.visibility}</span>
-        <select
-          value={form.visibility}
-          onChange={(event) =>
-            onChange({ ...form, visibility: event.target.value as MastodonVisibility })
-          }
-          className={selectClass}
-        >
-          {VISIBILITY_OPTIONS.map((visibility) => (
-            <option key={visibility} value={visibility}>
-              {visibilityLabels[visibility]}
-            </option>
-          ))}
-        </select>
-      </label>
-      {showActiveField && (
-        <div className="flex items-end justify-between gap-3 rounded-control border border-[var(--ds-border)] px-3 py-2">
-          <span className="text-sm font-medium text-[var(--ds-text)]">{labels.active}</span>
-          <ToggleSwitch
-            checked={form.isActive}
-            onChange={(isActive) => onChange({ ...form, isActive })}
-          />
-        </div>
-      )}
-    </div>
-  );
-}
-
-export function SocialMediaAccountsPage() {
+export function SocialMediaAccountsPage(): React.ReactElement {
   const { messages } = useI18n();
   const t = messages.socialMedia;
   const common = messages.common;
+
   const { data: accounts = [], isLoading } = useMastodonAccounts();
-  const createAccount = useCreateMastodonAccount();
   const updateAccount = useUpdateMastodonAccount();
   const deleteAccount = useDeleteMastodonAccount();
-  const [newForm, setNewForm] = useState(emptyForm);
-  const [editTarget, setEditTarget] = useState<MastodonAccount | null>(null);
-  const [editForm, setEditForm] = useState<MastodonAccountFormInput>(emptyForm);
+
+  const [dialogTarget, setDialogTarget] = useState<DialogTarget | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<MastodonAccount | null>(null);
-  const [error, setError] = useState<string | null>(null);
 
-  const isCreating = createAccount.isPending;
-  const isUpdating = updateAccount.isPending;
+  // ─── Groups ─────────────────────────────────────────────────────────────
 
-  function handleCreate() {
-    setError(null);
-    if (!newForm.accessToken?.trim()) {
-      setError(t.tokenRequired);
-      return;
-    }
-    createAccount.mutate(
-      { ...newForm, accessToken: newForm.accessToken.trim() },
+  const groups = useMemo<DataTableGroup<MastodonAccount>[]>(() => {
+    const mastodon = accounts.filter(() => true); // all accounts are mastodon for now
+    if (mastodon.length === 0) return [];
+    const platform = PLATFORM_MAP.get("mastodon");
+    if (!platform) return [];
+    const Icon = platform.icon;
+    return [
       {
-        onSuccess: () => setNewForm(emptyForm()),
-        onError: (err) => {
-          const apiErr = err as ApiRequestError;
-          if (apiErr.status === 400) {
-            setError(t.tokenInvalid);
-          } else if (apiErr.status === 503) {
-            setError(t.instanceUnreachable);
-          } else {
-            setError(t.saveError);
-          }
-        },
+        id: "mastodon",
+        header: (
+          <span className="flex items-center gap-1.5">
+            <Icon size={14} />
+            {`${platform.label} · ${mastodon.length}`}
+          </span>
+        ),
+        rows: mastodon,
       },
-    );
-  }
+    ];
+  }, [accounts]);
 
-  function openEdit(account: MastodonAccount) {
-    setError(null);
-    setEditTarget(account);
-    setEditForm(formFromAccount(account));
-  }
+  // ─── Columns ────────────────────────────────────────────────────────────
 
-  function handleUpdate() {
-    if (!editTarget) return;
-    setError(null);
-    updateAccount.mutate(
+  const columns: ColumnDef<MastodonAccount>[] = useMemo(
+    () => [
       {
-        id: editTarget.id,
-        input: {
-          ...editForm,
-          accessToken: editForm.accessToken?.trim() || undefined,
-        },
+        id: "label",
+        header: t.columns.account,
+        sortKey: (row) => row.label,
+        cell: (row) => (
+          <span className="font-medium text-[var(--ds-text)]">{row.label}</span>
+        ),
       },
       {
-        onSuccess: () => setEditTarget(null),
-        onError: (err) => {
-          const apiErr = err as ApiRequestError;
-          if (apiErr.status === 400) {
-            setError(t.tokenInvalid);
-          } else if (apiErr.status === 503) {
-            setError(t.instanceUnreachable);
-          } else {
-            setError(t.saveError);
-          }
-        },
+        id: "instance",
+        header: t.columns.instance,
+        sortKey: (row) => row.instanceUrl,
+        cell: (row) => (
+          <span className="text-[var(--ds-text-muted)]">{row.instanceUrl}</span>
+        ),
       },
-    );
-  }
+      {
+        id: "visibility",
+        header: t.columns.visibility,
+        sortKey: (row) => t.visibility[row.visibility],
+        cell: (row) => (
+          <span className="text-[var(--ds-text-muted)]">{t.visibility[row.visibility]}</span>
+        ),
+      },
+      {
+        id: "tokenStatus",
+        header: t.columns.token,
+        cell: (row) => (
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+              row.hasAccessToken
+                ? "bg-green-500/10 text-green-600 dark:text-green-400"
+                : "bg-[var(--ds-surface-hover)] text-[var(--ds-text-muted)]"
+            }`}
+          >
+            {row.hasAccessToken ? t.tokenStored : t.tokenMissing}
+          </span>
+        ),
+      },
+      {
+        id: "active",
+        header: t.columns.status,
+        sortKey: (row) => Number(row.isActive),
+        cell: (row) => (
+          <ToggleSwitch
+            checked={row.isActive}
+            disabled={updateAccount.isPending}
+            onChange={(value) =>
+              updateAccount.mutate({ id: row.id, input: { isActive: value } })
+            }
+          />
+        ),
+      },
+      {
+        id: "actions",
+        header: "",
+        cellClassName: "text-right",
+        cell: (row) => (
+          <div className="flex items-center justify-end gap-2">
+            <TableActionButton
+              variant="neutral"
+              icon={<PencilSimpleIcon weight="duotone" className="w-3.5 h-3.5" />}
+              label={common.edit}
+              onClick={() => setDialogTarget({ mode: "edit", account: row })}
+            />
+            <TableActionButton
+              variant="danger"
+              icon={<TrashIcon weight="duotone" className="w-3.5 h-3.5" />}
+              label={common.delete}
+              onClick={() => setDeleteTarget(row)}
+            />
+          </div>
+        ),
+      },
+    ],
+    [t, common, updateAccount],
+  );
+
+  // ─── Render ──────────────────────────────────────────────────────────────
 
   return (
     <PageLayout>
-      <PageHeader title={t.title} />
+      <PageHeader title={t.title}>
+        <button
+          type="button"
+          onClick={() => setDialogTarget({ mode: "create" })}
+          className="flex items-center gap-2 h-9 px-4 border border-[var(--ds-btn-primary-border)] text-[var(--ds-btn-primary-text)] rounded-control text-sm font-medium hover:border-[var(--ds-btn-primary-hover-border)] hover:bg-[var(--ds-btn-primary-hover-bg)]"
+        >
+          <PlusCircleIcon weight="duotone" className="w-3.5 h-3.5" />
+          {t.addAccountTitle}
+        </button>
+      </PageHeader>
 
-      <PageBody className="gap-4">
-        <DashboardSection>
-          <DashboardSection.Header
-            icon={<MastodonLogoIcon weight="duotone" className="h-4 w-4" />}
-            title={t.newAccount}
-            subtitle={t.mastodonHint}
-            addOn={
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-[var(--ds-text-muted)]">
-                  {t.fields.active}
-                </span>
-                <ToggleSwitch
-                  checked={newForm.isActive}
-                  onChange={(isActive) => setNewForm({ ...newForm, isActive })}
-                />
-              </div>
-            }
-          />
-          <DashboardSection.Body>
-            <AccountForm
-              form={newForm}
-              onChange={setNewForm}
-              visibilityLabels={t.visibility}
-              labels={t.fields}
-              tokenPlaceholder={t.accessTokenPlaceholder}
-              requireToken
-              showActiveField={false}
-            />
-          </DashboardSection.Body>
-          <DashboardSection.Footer className="justify-end">
-            {error && <p className="text-xs text-red-500">{error}</p>}
-            <button
-              type="button"
-              onClick={handleCreate}
-              disabled={isCreating}
-              className="flex h-9 items-center gap-2 rounded-control border border-[var(--ds-btn-primary-border)] px-4 text-sm font-medium text-[var(--ds-btn-primary-text)] hover:border-[var(--ds-btn-primary-hover-border)] hover:bg-[var(--ds-btn-primary-hover-bg)] disabled:opacity-60"
-            >
-              <PlusCircleIcon weight="duotone" className="h-3.5 w-3.5" />
-              {isCreating ? common.saving : t.addAccount}
-            </button>
-          </DashboardSection.Footer>
-        </DashboardSection>
-
+      <PageBody>
         {isLoading && (
           <div className="flex h-32 items-center justify-center text-sm text-[var(--ds-text-muted)]">
             {common.loading}
@@ -288,7 +173,6 @@ export function SocialMediaAccountsPage() {
         {!isLoading && accounts.length === 0 && (
           <ContentUnavailableView
             chromeless
-            className="min-h-64"
             icon={<MastodonLogoIcon weight="duotone" aria-hidden />}
             title={t.noAccounts}
             subtitle={t.noAccountsHint}
@@ -296,106 +180,20 @@ export function SocialMediaAccountsPage() {
         )}
 
         {!isLoading && accounts.length > 0 && (
-          <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
-            {accounts.map((account) => (
-              <article
-                key={account.id}
-                className="rounded-card border border-[var(--ds-border-subtle)] bg-[var(--ds-surface)] p-4"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <MastodonLogoIcon
-                        weight="duotone"
-                        className="h-4 w-4 text-[var(--ds-text-muted)]"
-                      />
-                      <h2 className="truncate text-sm font-semibold text-[var(--ds-text)]">
-                        {account.label}
-                      </h2>
-                    </div>
-                    <p className="mt-1 truncate text-xs text-[var(--ds-text-muted)]">
-                      {account.instanceUrl}
-                      {account.username ? ` · ${account.username}` : ""}
-                    </p>
-                  </div>
-                  <span
-                    className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
-                      account.isActive
-                        ? "bg-green-500/10 text-green-600 dark:text-green-400"
-                        : "bg-[var(--ds-surface-hover)] text-[var(--ds-text-muted)]"
-                    }`}
-                  >
-                    {account.isActive ? (
-                      <CheckCircleIcon weight="duotone" className="h-3 w-3" />
-                    ) : (
-                      <XCircleIcon weight="duotone" className="h-3 w-3" />
-                    )}
-                    {account.isActive ? t.active : t.inactive}
-                  </span>
-                </div>
-                <div className="mt-3 flex items-center justify-between text-xs text-[var(--ds-text-muted)]">
-                  <span>{t.visibility[account.visibility]}</span>
-                  <span>{account.hasAccessToken ? t.tokenStored : t.tokenMissing}</span>
-                </div>
-                <div className="mt-4 flex justify-end gap-2">
-                  <button
-                    type="button"
-                    onClick={() => openEdit(account)}
-                    className="h-9 rounded-control border border-[var(--ds-border)] px-3 text-sm text-[var(--ds-text-muted)] hover:border-[var(--ds-border-strong)] hover:text-[var(--ds-text)]"
-                  >
-                    {common.edit}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setDeleteTarget(account)}
-                    className="flex h-9 items-center gap-2 rounded-control border border-[var(--ds-btn-danger-border)] px-3 text-sm text-[var(--ds-btn-danger-text)] hover:border-[var(--ds-btn-danger-hover-border)] hover:bg-[var(--ds-btn-danger-hover-bg)]"
-                  >
-                    <TrashIcon weight="duotone" className="h-3.5 w-3.5" />
-                    {common.delete}
-                  </button>
-                </div>
-              </article>
-            ))}
-          </div>
+          <DataTable
+            columns={columns}
+            groups={groups}
+            getRowKey={(row) => row.id}
+            stickyHeader
+          />
         )}
       </PageBody>
 
-      {editTarget && (
-        <Dialog
-          open
-          title={t.editAccount}
-          titleIcon={<MastodonLogoIcon weight="duotone" className={dialogHeaderIconClass} />}
-          onClose={() => { setEditTarget(null); setError(null); }}
-        >
-          <div className="px-6 py-4">
-            <AccountForm
-              form={editForm}
-              onChange={setEditForm}
-              visibilityLabels={t.visibility}
-              labels={t.fields}
-              tokenPlaceholder={t.keepTokenPlaceholder}
-              requireToken={false}
-            />
-          </div>
-          <Dialog.Footer>
-            {error && <p className="text-xs text-red-500">{error}</p>}
-            <button
-              type="button"
-              onClick={() => setEditTarget(null)}
-              className={dialogBtnSecondary}
-            >
-              {common.cancel}
-            </button>
-            <button
-              type="button"
-              onClick={handleUpdate}
-              disabled={isUpdating}
-              className="h-9 rounded-control border border-[var(--ds-btn-primary-border)] px-4 text-sm font-medium text-[var(--ds-btn-primary-text)] hover:border-[var(--ds-btn-primary-hover-border)] hover:bg-[var(--ds-btn-primary-hover-bg)] disabled:opacity-60"
-            >
-              {isUpdating ? common.saving : common.save}
-            </button>
-          </Dialog.Footer>
-        </Dialog>
+      {dialogTarget && (
+        <AccountFormDialog
+          target={dialogTarget}
+          onClose={() => setDialogTarget(null)}
+        />
       )}
 
       {deleteTarget && (

--- a/apps/dashboard/src/features/social/forms/MastodonAccountForm.tsx
+++ b/apps/dashboard/src/features/social/forms/MastodonAccountForm.tsx
@@ -1,0 +1,105 @@
+import type React from "react";
+
+import type { MastodonVisibility } from "@lmaa/contracts";
+import { ToggleSwitch, formInputClass } from "@lmaa/ui";
+
+import type { MastodonAccountFormInput } from "@/features/social/hooks/useMastodonAccounts.ts";
+
+const VISIBILITY_OPTIONS: MastodonVisibility[] = ["public", "unlisted", "private", "direct"];
+
+interface MastodonAccountFormProps {
+  form: MastodonAccountFormInput;
+  onChange: (form: MastodonAccountFormInput) => void;
+  visibilityLabels: Record<MastodonVisibility, string>;
+  labels: {
+    label: string;
+    instanceUrl: string;
+    username: string;
+    accessToken: string;
+    accessTokenOptional: string;
+    visibility: string;
+    active: string;
+  };
+  tokenPlaceholder: string;
+  /** When true the access token field is required (create mode). */
+  requireToken: boolean;
+}
+
+export function MastodonAccountForm({
+  form,
+  onChange,
+  visibilityLabels,
+  labels,
+  tokenPlaceholder,
+  requireToken,
+}: MastodonAccountFormProps): React.ReactElement {
+  return (
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+      <label className="space-y-1">
+        <span className="text-xs font-medium text-[var(--ds-text-muted)]">{labels.label}</span>
+        <input
+          value={form.label}
+          onChange={(event) => onChange({ ...form, label: event.target.value })}
+          className={formInputClass}
+          placeholder="lmaa.space"
+        />
+      </label>
+      <label className="space-y-1">
+        <span className="text-xs font-medium text-[var(--ds-text-muted)]">
+          {labels.instanceUrl}
+        </span>
+        <input
+          value={form.instanceUrl}
+          onChange={(event) => onChange({ ...form, instanceUrl: event.target.value })}
+          className={formInputClass}
+          placeholder="https://mastodon.social"
+        />
+      </label>
+      <label className="space-y-1">
+        <span className="text-xs font-medium text-[var(--ds-text-muted)]">{labels.username}</span>
+        <input
+          value={form.username ?? ""}
+          onChange={(event) => onChange({ ...form, username: event.target.value })}
+          className={formInputClass}
+          placeholder="@lmaa"
+        />
+      </label>
+      <label className="space-y-1">
+        <span className="text-xs font-medium text-[var(--ds-text-muted)]">
+          {requireToken ? labels.accessToken : labels.accessTokenOptional}
+        </span>
+        <input
+          type="password"
+          value={form.accessToken ?? ""}
+          onChange={(event) => onChange({ ...form, accessToken: event.target.value })}
+          className={formInputClass}
+          placeholder={tokenPlaceholder}
+          autoComplete="new-password"
+        />
+      </label>
+      <label className="space-y-1">
+        <span className="text-xs font-medium text-[var(--ds-text-muted)]">{labels.visibility}</span>
+        <select
+          value={form.visibility}
+          onChange={(event) =>
+            onChange({ ...form, visibility: event.target.value as MastodonVisibility })
+          }
+          className={formInputClass}
+        >
+          {VISIBILITY_OPTIONS.map((visibility) => (
+            <option key={visibility} value={visibility}>
+              {visibilityLabels[visibility]}
+            </option>
+          ))}
+        </select>
+      </label>
+      <div className="flex items-end justify-between gap-3 rounded-control border border-[var(--ds-border)] px-3 py-2">
+        <span className="text-sm font-medium text-[var(--ds-text)]">{labels.active}</span>
+        <ToggleSwitch
+          checked={form.isActive}
+          onChange={(isActive) => onChange({ ...form, isActive })}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/features/social/forms/MastodonAccountForm.tsx
+++ b/apps/dashboard/src/features/social/forms/MastodonAccountForm.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
 
 import type { MastodonVisibility } from "@lmaa/contracts";
-import { ToggleSwitch, formInputClass } from "@lmaa/ui";
+import { formInputClass } from "@lmaa/ui";
 
 import type { MastodonAccountFormInput } from "@/features/social/hooks/useMastodonAccounts.ts";
 
@@ -18,7 +18,6 @@ interface MastodonAccountFormProps {
     accessToken: string;
     accessTokenOptional: string;
     visibility: string;
-    active: string;
   };
   tokenPlaceholder: string;
   /** When true the access token field is required (create mode). */
@@ -93,13 +92,6 @@ export function MastodonAccountForm({
           ))}
         </select>
       </label>
-      <div className="flex items-end justify-between gap-3 rounded-control border border-[var(--ds-border)] px-3 py-2">
-        <span className="text-sm font-medium text-[var(--ds-text)]">{labels.active}</span>
-        <ToggleSwitch
-          checked={form.isActive}
-          onChange={(isActive) => onChange({ ...form, isActive })}
-        />
-      </div>
     </div>
   );
 }

--- a/apps/dashboard/src/features/social/services.ts
+++ b/apps/dashboard/src/features/social/services.ts
@@ -1,0 +1,12 @@
+import { PLATFORM_MAP, type PlatformDef } from "@lmaa/ui";
+
+/** Service keys that have a working backend implementation in this dashboard. */
+export type ServiceId = "mastodon";
+
+/** Ordered list of currently-supported services. Add new entries as backends ship. */
+export const SUPPORTED_SERVICE_KEYS: readonly ServiceId[] = ["mastodon"] as const;
+
+/** PlatformDef entries for the supported services, in `SUPPORTED_SERVICE_KEYS` order. */
+export const SUPPORTED_PLATFORMS: PlatformDef[] = SUPPORTED_SERVICE_KEYS
+  .map((key) => PLATFORM_MAP.get(key))
+  .filter((p): p is PlatformDef => p !== undefined);

--- a/apps/dashboard/src/i18n/messages.ts
+++ b/apps/dashboard/src/i18n/messages.ts
@@ -989,6 +989,10 @@ export interface DashboardMessages {
     deleteConfirm: string;
     accessTokenPlaceholder: string;
     keepTokenPlaceholder: string;
+    addAccountTitle: string;
+    pickService: string;
+    changeService: string;
+    addMastodonAccount: string;
     fields: {
       label: string;
       instanceUrl: string;
@@ -999,6 +1003,13 @@ export interface DashboardMessages {
       active: string;
     };
     visibility: Record<"public" | "unlisted" | "private" | "direct", string>;
+    columns: {
+      account: string;
+      instance: string;
+      visibility: string;
+      token: string;
+      status: string;
+    };
   };
   affiliate: {
     title: string;
@@ -2158,7 +2169,7 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
       mastodonHint:
         "Für automatische Posts wird ein User Access Token mit Scope write:statuses benötigt.",
       noAccounts: "Keine Accounts konfiguriert.",
-      noAccountsHint: "Hinterlege einen Mastodon Account für automatische Postings.",
+      noAccountsHint: "Hinterlege einen Social Media Account für automatische Postings.",
       active: "Aktiv",
       inactive: "Inaktiv",
       tokenStored: "Token hinterlegt",
@@ -2171,6 +2182,10 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
       deleteConfirm: "Diesen Account wirklich löschen?",
       accessTokenPlaceholder: "Mastodon User Access Token",
       keepTokenPlaceholder: "Leer lassen, um den aktuellen Token zu behalten",
+      addAccountTitle: "Account hinzufügen",
+      pickService: "Wähle einen Dienst",
+      changeService: "Anderen Dienst wählen",
+      addMastodonAccount: "Mastodon Account hinzufügen",
       fields: {
         label: "Label",
         instanceUrl: "Instanz-URL",
@@ -2185,6 +2200,13 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
         unlisted: "Unlisted",
         private: "Private",
         direct: "Direct",
+      },
+      columns: {
+        account: "Account",
+        instance: "Instanz",
+        visibility: "Sichtbarkeit",
+        token: "Token",
+        status: "Status",
       },
     },
     affiliate: {
@@ -3335,7 +3357,7 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
       addAccount: "Save account",
       mastodonHint: "Automatic posts require a user access token with the write:statuses scope.",
       noAccounts: "No accounts configured.",
-      noAccountsHint: "Add a Mastodon account for automatic posts.",
+      noAccountsHint: "Add a social media account for automated postings.",
       active: "Active",
       inactive: "Inactive",
       tokenStored: "Token stored",
@@ -3348,6 +3370,10 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
       deleteConfirm: "Really delete this account?",
       accessTokenPlaceholder: "Mastodon user access token",
       keepTokenPlaceholder: "Leave empty to keep the current token",
+      addAccountTitle: "Add account",
+      pickService: "Choose a service",
+      changeService: "Choose a different service",
+      addMastodonAccount: "Add Mastodon account",
       fields: {
         label: "Label",
         instanceUrl: "Instance URL",
@@ -3362,6 +3388,13 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
         unlisted: "Unlisted",
         private: "Private",
         direct: "Direct",
+      },
+      columns: {
+        account: "Account",
+        instance: "Instance",
+        visibility: "Visibility",
+        token: "Token",
+        status: "Status",
       },
     },
     affiliate: {

--- a/apps/dashboard/src/i18n/messages.ts
+++ b/apps/dashboard/src/i18n/messages.ts
@@ -971,14 +971,9 @@ export interface DashboardMessages {
   };
   socialMedia: {
     title: string;
-    newAccount: string;
     editAccount: string;
-    addAccount: string;
-    mastodonHint: string;
     noAccounts: string;
     noAccountsHint: string;
-    active: string;
-    inactive: string;
     tokenStored: string;
     tokenMissing: string;
     tokenRequired: string;
@@ -2163,15 +2158,9 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
     },
     socialMedia: {
       title: "Social Media Accounts",
-      newAccount: "Mastodon Account hinzufügen",
       editAccount: "Mastodon Account bearbeiten",
-      addAccount: "Account speichern",
-      mastodonHint:
-        "Für automatische Posts wird ein User Access Token mit Scope write:statuses benötigt.",
       noAccounts: "Keine Accounts konfiguriert.",
       noAccountsHint: "Hinterlege einen Social Media Account für automatische Postings.",
-      active: "Aktiv",
-      inactive: "Inaktiv",
       tokenStored: "Token hinterlegt",
       tokenMissing: "Kein Token",
       tokenRequired: "Bitte einen Access Token hinterlegen.",
@@ -3352,14 +3341,9 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
     },
     socialMedia: {
       title: "Social Media Accounts",
-      newAccount: "Add Mastodon account",
       editAccount: "Edit Mastodon account",
-      addAccount: "Save account",
-      mastodonHint: "Automatic posts require a user access token with the write:statuses scope.",
       noAccounts: "No accounts configured.",
       noAccountsHint: "Add a social media account for automated postings.",
-      active: "Active",
-      inactive: "Inactive",
       tokenStored: "Token stored",
       tokenMissing: "No token",
       tokenRequired: "Please enter an access token.",

--- a/packages/ui/src/Dialog.tsx
+++ b/packages/ui/src/Dialog.tsx
@@ -8,7 +8,7 @@ interface DialogProps {
 	titleIcon?: ReactNode;
 	onClose: () => void;
 	children: ReactNode;
-	maxWidth?: "sm" | "md";
+	maxWidth?: "sm" | "md" | "lg";
 }
 
 interface DialogFooterProps {
@@ -29,7 +29,7 @@ function DialogFooter({ children, className }: DialogFooterProps) {
 export const dialogHeaderIconClass = "w-6 h-6 shrink-0 text-[var(--ds-text-muted)]";
 
 export function Dialog({ open, title, titleIcon, onClose, children, maxWidth = "sm" }: DialogProps) {
-	const size = maxWidth === "md" ? "fixed-md" : "fixed-sm";
+	const size = maxWidth === "lg" ? "fixed-lg" : maxWidth === "md" ? "fixed-md" : "fixed-sm";
 
 	return (
 		<OverlayCard open={open} onClose={onClose} size={size} aria-label={title}>

--- a/packages/ui/src/OverlayCard.tsx
+++ b/packages/ui/src/OverlayCard.tsx
@@ -56,7 +56,7 @@ function ensureStyles() {
 interface OverlayCardProps {
 	open: boolean;
 	onClose: () => void;
-	size?: "fixed-sm" | "fixed-md";
+	size?: "fixed-sm" | "fixed-md" | "fixed-lg";
 	"aria-label": string;
 	className?: string;
 	style?: React.CSSProperties;
@@ -223,7 +223,8 @@ export function OverlayCard({
 
 	const handleBackdropClick = isTopMost && backdropClose && !closing ? startClose : undefined;
 
-	const fixedMaxWidth = size === "fixed-md" ? "max-w-md" : "max-w-sm";
+	const fixedMaxWidth =
+		size === "fixed-lg" ? "max-w-lg" : size === "fixed-md" ? "max-w-md" : "max-w-sm";
 	const cardAnim = closing ? "lmaa-card-out 280ms ease forwards" : "lmaa-card-in 380ms ease forwards";
 	const backdropAnim = closing ? "lmaa-overlay-out 280ms ease forwards" : "lmaa-overlay-in 360ms ease forwards";
 	const effectiveZIndex = isRegistered ? zIndex + stackIndex * 100 : zIndex;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -76,6 +76,9 @@ export type { SocialMediaEditorMessages, SocialMediaEditorProps } from "./Social
 /** Read-only social media icon links (server-renderable). */
 export { SocialMediaIcons } from "./SocialMediaIcons.tsx";
 export type { SocialMediaIconsProps } from "./SocialMediaIcons.tsx";
+/** Social media platform registry (ordered list + O(1) map). */
+export { PLATFORMS, PLATFORM_MAP } from "./social-media-platforms.ts";
+export type { PlatformDef } from "./social-media-platforms.ts";
 /** Shared tab navigation component. */
 export { Tabs, TabList, TabTrigger, TabContent } from "./Tabs.tsx";
 /** Re-exported props for Tabs. */

--- a/packages/ui/src/social-media-platforms.ts
+++ b/packages/ui/src/social-media-platforms.ts
@@ -22,7 +22,7 @@ import {
 } from "react-icons/si";
 
 /** Definition of a social media platform including its display label and icon component. */
-interface PlatformDef {
+export interface PlatformDef {
   key: string;
   label: string;
   icon: ComponentType<{ size?: number }>;


### PR DESCRIPTION
## Summary

- Rebuild `/system/social-media-accounts` around a list-with-modal model: page body shows either the centered empty state or a single grouped `DataTable`, with a primary "Add account" action in the page header that opens a service-picker → form dialog.
- Extend `DataTable` with optional `groups` prop (additive — no breaking change for existing callers): renders section-header rows interspersed with sorted data rows, stripe continues across groups.
- Polish: dialog widened to `max-w-lg` (new `"lg"` size on `Dialog`/`OverlayCard`), Aktiv toggle moved into the action bar opposite the back-link, `socialMedia` i18n cleaned of orphaned keys.

## Test plan

- [ ] Empty state — only the centered `ContentUnavailableView` renders, header still shows "Account hinzufügen"
- [ ] Click "Account hinzufügen" — modal opens at the service picker (Stage A)
- [ ] Pick Mastodon — Stage B form opens with empty fields, Aktiv toggle visible top-right of the action bar
- [ ] Save with valid label + instanceUrl + accessToken — 201, modal closes, account appears in DataTable under "Mastodon" group header
- [ ] Save with bogus token — 400 surfaces as `tokenInvalid` in the dialog footer
- [ ] Inline ToggleSwitch on the row — PUT fires, status flips, toggle disabled while pending
- [ ] Edit row — modal opens at Stage B (no picker), prefilled, access token field empty with "keep current" placeholder
- [ ] Delete row — confirmation dialog → confirm → row gone
- [ ] Remove all accounts — page returns to centered empty state