### PR TITLE
Feat: Link shop name in 'already submitted' dialog + RickRoll for Amazon URLs

### DIFF
--- a/apps/backend/src/__tests__/public-service.test.ts
+++ b/apps/backend/src/__tests__/public-service.test.ts
@@ -64,6 +64,7 @@ import {
   getManagedPublicStats,
   getPublicFilterOptions,
   hashIp,
+  isAmazonStoreHostname,
   normalizeShopHostname,
   searchFilteredPublicCatalog,
   searchManagedPublicCatalog,
@@ -244,6 +245,36 @@ describe("searchManagedPublicCatalog", () => {
   });
 });
 
+describe("isAmazonStoreHostname", () => {
+  it("matches plain Amazon storefront domains", () => {
+    expect(isAmazonStoreHostname("amazon.de")).toBe(true);
+    expect(isAmazonStoreHostname("amazon.com")).toBe(true);
+    expect(isAmazonStoreHostname("amazon.co.uk")).toBe(true);
+    expect(isAmazonStoreHostname("amazon.com.br")).toBe(true);
+    expect(isAmazonStoreHostname("amazon.co.jp")).toBe(true);
+  });
+
+  it("matches Amazon shorteners", () => {
+    expect(isAmazonStoreHostname("amzn.to")).toBe(true);
+    expect(isAmazonStoreHostname("amzn.eu")).toBe(true);
+  });
+
+  it("matches subdomains of Amazon storefronts", () => {
+    expect(isAmazonStoreHostname("kindle.amazon.de")).toBe(true);
+    expect(isAmazonStoreHostname("smile.amazon.com")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isAmazonStoreHostname("AMAZON.DE")).toBe(true);
+  });
+
+  it("does not match unrelated domains containing the word amazon", () => {
+    expect(isAmazonStoreHostname("notamazon.com")).toBe(false);
+    expect(isAmazonStoreHostname("amazon.example.com")).toBe(false);
+    expect(isAmazonStoreHostname("example.com")).toBe(false);
+  });
+});
+
 describe("validateShopUrl", () => {
   beforeEach(() => vi.clearAllMocks());
 
@@ -252,12 +283,43 @@ describe("validateShopUrl", () => {
     expect(result).toEqual({ status: "available" });
   });
 
-  it("returns published when shop exists", async () => {
-    publicRepoMocks.findShopByDomain.mockResolvedValue({ name: "Shop", visibility: "public" });
+  it("returns published with detail link when shop exists", async () => {
+    publicRepoMocks.findShopByDomain.mockResolvedValue({
+      id: 42,
+      name: "Shop",
+      visibility: "public",
+    });
 
     const result = await validateShopUrl("https://shop.de");
 
-    expect(result).toEqual({ status: "published", shopName: "Shop" });
+    expect(result).toEqual({
+      status: "published",
+      shopName: "Shop",
+      shopUrl: expect.stringMatching(/^\/shop\/[a-z0-9]+$/),
+    });
+  });
+
+  it("returns published with RickRoll for Amazon URLs without DB lookup", async () => {
+    const result = await validateShopUrl("https://www.amazon.de/dp/B000123");
+
+    expect(result).toEqual({
+      status: "published",
+      shopName: "Amazon",
+      shopUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    expect(publicRepoMocks.findShopByDomain).not.toHaveBeenCalled();
+    expect(publicRepoMocks.findRejectedSubmissionByDomain).not.toHaveBeenCalled();
+    expect(publicRepoMocks.findPendingSubmissionByDomain).not.toHaveBeenCalled();
+  });
+
+  it("returns published with RickRoll for amzn.to short links", async () => {
+    const result = await validateShopUrl("https://amzn.to/3xyz");
+
+    expect(result).toEqual({
+      status: "published",
+      shopName: "Amazon",
+      shopUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
   });
 
   it("returns rejected with URL when shop is rejected", async () => {

--- a/apps/backend/src/routes/public.ts
+++ b/apps/backend/src/routes/public.ts
@@ -152,6 +152,7 @@ publicRoutes.post(
             message: "Der Shop ist bereits eingetragen.",
             status: "published",
             shopName: urlCheck.shopName,
+            shopUrl: urlCheck.shopUrl,
           },
         });
       }

--- a/apps/backend/src/services/public.ts
+++ b/apps/backend/src/services/public.ts
@@ -2,6 +2,8 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 
 import { getDomain } from "tldts";
 
+import { encodeShopToken } from "@lmaa/shared";
+
 import { env } from "../config/env.js";
 import { extractEuropeanPostalCodePrefix } from "../lib/postal-code.js";
 import { type Result, failure, success } from "../lib/result.js";
@@ -57,6 +59,49 @@ const SHOPS_CACHE_TTL_MS = 60 * 1000;
 export function normalizeShopHostname(url: string): string | null {
   const input = url.includes("://") ? url : `https://${url}`;
   return getDomain(input) ?? null;
+}
+
+const AMAZON_STORE_DOMAINS = [
+  "amazon.com",
+  "amazon.ca",
+  "amazon.com.mx",
+  "amazon.com.br",
+  "amazon.co.uk",
+  "amazon.de",
+  "amazon.fr",
+  "amazon.it",
+  "amazon.es",
+  "amazon.nl",
+  "amazon.se",
+  "amazon.pl",
+  "amazon.com.tr",
+  "amazon.com.be",
+  "amazon.eg",
+  "amazon.sa",
+  "amazon.ae",
+  "amazon.in",
+  "amazon.com.au",
+  "amazon.co.jp",
+  "amazon.sg",
+  "amazon.cn",
+  "amazon.ie",
+  "amzn.to",
+  "amzn.eu",
+  "amzn.com",
+  "amzn.in",
+  "amzn.de",
+  "amzn.es",
+  "amzn.fr",
+  "amzn.it",
+  "amzn.uk",
+  "amzn.asia",
+] as const;
+
+const AMAZON_RICKROLL_URL = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+export function isAmazonStoreHostname(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+  return AMAZON_STORE_DOMAINS.some((d) => lower === d || lower.endsWith(`.${d}`));
 }
 
 /**
@@ -267,6 +312,14 @@ export async function validateShopUrl(urlRaw: string | undefined) {
     return { status: "available" as const };
   }
 
+  if (isAmazonStoreHostname(domain)) {
+    return {
+      status: "published" as const,
+      shopName: "Amazon",
+      shopUrl: AMAZON_RICKROLL_URL,
+    };
+  }
+
   const match = await findShopByDomain(domain);
   if (match) {
     if (match.visibility === "rejected") {
@@ -280,6 +333,7 @@ export async function validateShopUrl(urlRaw: string | undefined) {
     return {
       status: "published" as const,
       shopName: match.name,
+      shopUrl: `/shop/${encodeShopToken(match.id)}`,
     };
   }
 

--- a/apps/frontend/src/components/islands/DynamicForm.tsx
+++ b/apps/frontend/src/components/islands/DynamicForm.tsx
@@ -867,6 +867,21 @@ function RichTextBlock({ field }: { field: FormField }) {
   );
 }
 
+function PublishedShopName({ name, url }: { name: string | undefined; url: string | undefined }) {
+  if (!name) return null;
+  if (!url) return <strong>{name}</strong>;
+  const isExternal = /^https?:\/\//i.test(url);
+  return (
+    <a
+      href={url}
+      className="font-bold text-[var(--ds-accent)] underline hover:no-underline"
+      {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+    >
+      {name}
+    </a>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Form state (useReducer)
 // ---------------------------------------------------------------------------
@@ -880,6 +895,7 @@ interface FormState {
     message: string;
     status?: "published" | "rejected" | "pending" | "available";
     shopName?: string;
+    shopUrl?: string;
     rejectionUrl?: string;
   } | null;
   submitted: boolean;
@@ -907,6 +923,7 @@ function formReducer(s: FormState, patch: Partial<FormState>): FormState {
 interface CheckShopResult {
   status: "available" | "published" | "rejected" | "pending";
   shopName?: string;
+  shopUrl?: string;
   rejectionUrl?: string;
 }
 
@@ -990,6 +1007,7 @@ function ButtonField({
           onCheckShopResult({
             status,
             shopName: typeof data?.shopName === "string" ? data.shopName : undefined,
+            shopUrl: typeof data?.shopUrl === "string" ? data.shopUrl : undefined,
             rejectionUrl: typeof data?.rejectionUrl === "string" ? data.rejectionUrl : undefined,
           });
         } catch {
@@ -1346,6 +1364,7 @@ export default function DynamicForm({ formConfig, categories }: Props) {
               message: typeof errorObj?.message === "string" ? errorObj.message : "Dieser Shop ist bereits bekannt.",
               status,
               shopName: typeof errorObj?.shopName === "string" ? errorObj.shopName : undefined,
+              shopUrl: typeof errorObj?.shopUrl === "string" ? errorObj.shopUrl : undefined,
               rejectionUrl: typeof errorObj?.rejectionUrl === "string" ? errorObj.rejectionUrl : undefined,
             },
           });
@@ -1478,6 +1497,7 @@ export default function DynamicForm({ formConfig, categories }: Props) {
                                   message: "",
                                   status: result.status,
                                   shopName: result.shopName,
+                                  shopUrl: result.shopUrl,
                                   rejectionUrl: result.rejectionUrl,
                                 },
                               })
@@ -1546,7 +1566,7 @@ export default function DynamicForm({ formConfig, categories }: Props) {
             <p>
               Da hatte wohl jemand bereits die gleiche Idee!
               <br />
-              Der Shop <strong>{state.submitError?.shopName}</strong> ist schon eingetragen.
+              Der Shop <PublishedShopName name={state.submitError?.shopName} url={state.submitError?.shopUrl} /> ist schon eingetragen.
             </p>
           )}
         </AlertDialog>


### PR DESCRIPTION
## Summary

- Submission flow now surfaces the existing-shop dialog with a clickable shop name. For real DB matches it links to the internal `/shop/<token>` detail page; for any URL on an Amazon storefront domain it links to "Never Gonna Give You Up" instead.
- Amazon detection runs as a whitelist of `amazon.*` and `amzn.*` hostnames (incl. subdomains, case-insensitive) and short-circuits `validateShopUrl` before the DB lookup, so the gag fires regardless of whether the domain is registered.
- Both entry points that show the dialog (the check-shop button action and the form-submit 409 response) read the new `shopUrl` field; external targets open in a new tab with `rel="noopener noreferrer"`.

## Test plan

- [x] Backend: `validateShopUrl` for `amazon.de`, `amazon.de/dp/...`, `amzn.to/...`, `amazon.com.br` returns `{ status: "published", shopName: "Amazon", shopUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ" }` without hitting the DB.
- [x] Backend: `validateShopUrl` for an existing public shop returns the internal `/shop/<token>` URL.
- [x] Backend: unrelated domain (`example.com`) returns `available`.
- [x] Frontend: pre-check button with an Amazon URL shows "Shop bereits vorhanden" with "Amazon" as a YouTube link in a new tab.
- [x] Frontend: submit with an Amazon URL shows the same dialog from the 409 path.
- [x] Frontend: published DB match renders the shop name as an internal link to the detail page.
- [x] `npm run lint` clean, `npm run typecheck -w @lmaa/backend` clean, `vitest` 43/43 (including 8 new cases for `isAmazonStoreHostname` and the Amazon `validateShopUrl` bypass).