### PR TITLE
Feat: Add configurable domain alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ dist/
 *.db-wal
 .DS_Store
 *.tmp
+/.app/
+/app
+/app.config
+/test-results/
 .agents/
 .claude/
 .codex/

--- a/apps/backend/drizzle/0053_domain_alert_rules.sql
+++ b/apps/backend/drizzle/0053_domain_alert_rules.sql
@@ -1,0 +1,17 @@
+-- Custom SQL migration file, put your code below! --
+INSERT INTO app_settings (key, value)
+VALUES (
+  'submission.domainAlertRules',
+  $${
+    "rules": [
+      {
+        "id": "amazon-rickroll",
+        "name": "Amazon URLs",
+        "domainsText": "amazon.com, amazon.ca, amazon.com.mx, amazon.com.br, amazon.co.uk, amazon.de, amazon.fr, amazon.it, amazon.es, amazon.nl, amazon.se, amazon.pl, amazon.com.tr, amazon.com.be, amazon.eg, amazon.sa, amazon.ae, amazon.in, amazon.com.au, amazon.co.jp, amazon.sg, amazon.cn, amazon.ie, amzn.to, amzn.eu, amzn.com, amzn.in, amzn.de, amzn.es, amzn.fr, amzn.it, amzn.uk, amzn.asia",
+        "messageMarkdown": "Da hatte wohl jemand bereits die gleiche Idee! Der Shop [Amazon](https://www.youtube.com/watch?v=dQw4w9WgXcQ) ist schon eingetragen.",
+        "isActive": true
+      }
+    ]
+  }$$
+)
+ON CONFLICT (key) DO NOTHING;

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -372,6 +372,13 @@
       "when": 1778351067429,
       "tag": "0052_outstanding_true_believers",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1778361141823,
+      "tag": "0053_domain_alert_rules",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/__tests__/public-service.test.ts
+++ b/apps/backend/src/__tests__/public-service.test.ts
@@ -47,13 +47,19 @@ const envMock = vi.hoisted(() => ({
   env: { NODE_ENV: "development", IP_HASH_SALT: "test-salt-1234567890" },
 }));
 
+const appSettingsMocks = vi.hoisted(() => ({
+  getSetting: vi.fn(),
+}));
+
 vi.mock("../repositories/public.js", () => publicRepoMocks);
 vi.mock("../repositories/public-filtered.js", () => filteredRepoMocks);
 vi.mock("../repositories/headquarters.js", () => headquartersMocks);
+vi.mock("../repositories/app-settings.js", () => appSettingsMocks);
 vi.mock("../middleware/cache.js", () => cacheMocks);
 vi.mock("../config/env.js", () => envMock);
 vi.mock("../lib/result.js", async (importOriginal) => importOriginal());
 
+import { matchesDomainAlertRule } from "../services/domain-alert-rules.js";
 import {
   createManagedDeadLinkReport,
   createManagedShopConcernReport,
@@ -65,13 +71,31 @@ import {
   getManagedPublicStats,
   getPublicFilterOptions,
   hashIp,
-  isAmazonStoreHostname,
   normalizeShopHostname,
   searchFilteredPublicCatalog,
   searchManagedPublicCatalog,
   toggleShopLike,
   validateShopUrl,
 } from "../services/public.js";
+
+const DOMAIN_ALERT_MESSAGE =
+  "Da hatte wohl jemand bereits die gleiche Idee! Der Shop [Amazon](https://www.youtube.com/watch?v=dQw4w9WgXcQ) ist schon eingetragen.";
+
+function mockAmazonDomainAlertRule() {
+  appSettingsMocks.getSetting.mockResolvedValue(
+    JSON.stringify({
+      rules: [
+        {
+          id: "amazon-rickroll",
+          name: "Amazon URLs",
+          domainsText: "amazon.de, amazon.com, amazon.co.uk, amzn.to, amzn.eu",
+          messageMarkdown: DOMAIN_ALERT_MESSAGE,
+          isActive: true,
+        },
+      ],
+    }),
+  );
+}
 
 describe("normalizeShopHostname", () => {
   it("extracts root domain from full URL", () => {
@@ -289,38 +313,51 @@ describe("searchManagedPublicCatalog", () => {
   });
 });
 
-describe("isAmazonStoreHostname", () => {
-  it("matches plain Amazon storefront domains", () => {
-    expect(isAmazonStoreHostname("amazon.de")).toBe(true);
-    expect(isAmazonStoreHostname("amazon.com")).toBe(true);
-    expect(isAmazonStoreHostname("amazon.co.uk")).toBe(true);
-    expect(isAmazonStoreHostname("amazon.com.br")).toBe(true);
-    expect(isAmazonStoreHostname("amazon.co.jp")).toBe(true);
+describe("matchesDomainAlertRule", () => {
+  const rule = {
+    id: "amazon-rickroll",
+    name: "Amazon URLs",
+    domainsText: "amazon.de, amazon.com, amazon.co.uk, amzn.to, amzn.eu",
+    messageMarkdown: DOMAIN_ALERT_MESSAGE,
+    isActive: true,
+  };
+
+  it("matches configured domains and subdomains", () => {
+    expect(matchesDomainAlertRule("amazon.de", "amazon.de", rule)).toBe(true);
+    expect(matchesDomainAlertRule("kindle.amazon.de", "amazon.de", rule)).toBe(true);
+    expect(matchesDomainAlertRule("smile.amazon.com", "amazon.com", rule)).toBe(true);
   });
 
-  it("matches Amazon shorteners", () => {
-    expect(isAmazonStoreHostname("amzn.to")).toBe(true);
-    expect(isAmazonStoreHostname("amzn.eu")).toBe(true);
-  });
-
-  it("matches subdomains of Amazon storefronts", () => {
-    expect(isAmazonStoreHostname("kindle.amazon.de")).toBe(true);
-    expect(isAmazonStoreHostname("smile.amazon.com")).toBe(true);
+  it("matches configured shortener domains", () => {
+    expect(matchesDomainAlertRule("amzn.to", "amzn.to", rule)).toBe(true);
+    expect(matchesDomainAlertRule("www.amzn.eu", "amzn.eu", rule)).toBe(true);
   });
 
   it("is case-insensitive", () => {
-    expect(isAmazonStoreHostname("AMAZON.DE")).toBe(true);
+    expect(matchesDomainAlertRule("AMAZON.DE", "amazon.de", rule)).toBe(true);
   });
 
-  it("does not match unrelated domains containing the word amazon", () => {
-    expect(isAmazonStoreHostname("notamazon.com")).toBe(false);
-    expect(isAmazonStoreHostname("amazon.example.com")).toBe(false);
-    expect(isAmazonStoreHostname("example.com")).toBe(false);
+  it("does not match unrelated domains containing the configured label", () => {
+    expect(matchesDomainAlertRule("notamazon.com", "notamazon.com", rule)).toBe(false);
+    expect(matchesDomainAlertRule("amazon.example.com", "example.com", rule)).toBe(false);
+    expect(matchesDomainAlertRule("example.com", "example.com", rule)).toBe(false);
+  });
+
+  it("ignores disabled rules", () => {
+    expect(
+      matchesDomainAlertRule("amazon.de", "amazon.de", {
+        ...rule,
+        isActive: false,
+      }),
+    ).toBe(false);
   });
 });
 
 describe("validateShopUrl", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appSettingsMocks.getSetting.mockResolvedValue(null);
+  });
 
   it("returns available for empty URL", async () => {
     const result = await validateShopUrl(undefined);
@@ -343,26 +380,28 @@ describe("validateShopUrl", () => {
     });
   });
 
-  it("returns published with RickRoll for Amazon URLs without DB lookup", async () => {
+  it("returns blocked with configured alert for matching domains without DB lookup", async () => {
+    mockAmazonDomainAlertRule();
+
     const result = await validateShopUrl("https://www.amazon.de/dp/B000123");
 
     expect(result).toEqual({
-      status: "published",
-      shopName: "Amazon",
-      shopUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      status: "blocked",
+      messageMarkdown: DOMAIN_ALERT_MESSAGE,
     });
     expect(publicRepoMocks.findShopByDomain).not.toHaveBeenCalled();
     expect(publicRepoMocks.findRejectedSubmissionByDomain).not.toHaveBeenCalled();
     expect(publicRepoMocks.findPendingSubmissionByDomain).not.toHaveBeenCalled();
   });
 
-  it("returns published with RickRoll for amzn.to short links", async () => {
+  it("returns blocked with configured alert for short links", async () => {
+    mockAmazonDomainAlertRule();
+
     const result = await validateShopUrl("https://amzn.to/3xyz");
 
     expect(result).toEqual({
-      status: "published",
-      shopName: "Amazon",
-      shopUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      status: "blocked",
+      messageMarkdown: DOMAIN_ALERT_MESSAGE,
     });
   });
 

--- a/apps/backend/src/__tests__/validate-shop-url.test.ts
+++ b/apps/backend/src/__tests__/validate-shop-url.test.ts
@@ -6,18 +6,44 @@ const repoMocks = vi.hoisted(() => ({
   findPendingSubmissionByDomain: vi.fn(),
 }));
 
+const appSettingsMocks = vi.hoisted(() => ({
+  getSetting: vi.fn(),
+}));
+
 vi.mock("../repositories/public.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../repositories/public.js")>();
   return { ...actual, ...repoMocks };
 });
+vi.mock("../repositories/app-settings.js", () => appSettingsMocks);
 
 import { validateShopUrl } from "../services/public.js";
+
+const DOMAIN_ALERT_MESSAGE =
+  "Da hatte wohl jemand bereits die gleiche Idee! Der Shop [Amazon](https://www.youtube.com/watch?v=dQw4w9WgXcQ) ist schon eingetragen.";
+
+function mockDomainAlertRules(isActive = true) {
+  appSettingsMocks.getSetting.mockResolvedValue(
+    JSON.stringify({
+      rules: [
+        {
+          id: "amazon-rickroll",
+          name: "Amazon URLs",
+          domainsText: "amazon.de, amazon.com, amzn.to",
+          messageMarkdown: DOMAIN_ALERT_MESSAGE,
+          isActive,
+        },
+      ],
+    }),
+  );
+}
 
 describe("validateShopUrl", () => {
   beforeEach(() => {
     repoMocks.findShopByDomain.mockReset();
     repoMocks.findRejectedSubmissionByDomain.mockReset();
     repoMocks.findPendingSubmissionByDomain.mockReset();
+    appSettingsMocks.getSetting.mockReset();
+    appSettingsMocks.getSetting.mockResolvedValue(null);
   });
 
   it("returns available for undefined input", async () => {
@@ -85,16 +111,28 @@ describe("validateShopUrl", () => {
     });
   });
 
-  it("returns published with RickRoll for Amazon URLs without DB lookup", async () => {
+  it("returns blocked with configured alert for matching domains without DB lookup", async () => {
+    mockDomainAlertRules();
+
     const result = await validateShopUrl("https://www.amazon.de/dp/B000123");
     expect(result).toEqual({
-      status: "published",
-      shopName: "Amazon",
-      shopUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      status: "blocked",
+      messageMarkdown: DOMAIN_ALERT_MESSAGE,
     });
     expect(repoMocks.findShopByDomain).not.toHaveBeenCalled();
     expect(repoMocks.findRejectedSubmissionByDomain).not.toHaveBeenCalled();
     expect(repoMocks.findPendingSubmissionByDomain).not.toHaveBeenCalled();
+  });
+
+  it("ignores disabled domain alert rules", async () => {
+    mockDomainAlertRules(false);
+    repoMocks.findShopByDomain.mockResolvedValue(null);
+    repoMocks.findRejectedSubmissionByDomain.mockResolvedValue(null);
+    repoMocks.findPendingSubmissionByDomain.mockResolvedValue(null);
+
+    const result = await validateShopUrl("https://www.amazon.de/dp/B000123");
+    expect(result).toEqual({ status: "available" });
+    expect(repoMocks.findShopByDomain).toHaveBeenCalledWith("amazon.de");
   });
 
   it("returns rejected with rejectionUrl when shop was rejected", async () => {

--- a/apps/backend/src/docs/openapi-document.ts
+++ b/apps/backend/src/docs/openapi-document.ts
@@ -369,6 +369,14 @@ const schemas: Record<string, SchemaObject> = {
       {
         type: "object",
         properties: {
+          status: { type: "string", const: "blocked" },
+          messageMarkdown: { type: "string" },
+        },
+        required: ["status", "messageMarkdown"],
+      },
+      {
+        type: "object",
+        properties: {
           status: { type: "string", const: "published" },
           shopName: { type: "string" },
           shopUrl: { type: "string" },
@@ -533,7 +541,7 @@ export const publicOpenApiOperations: OpenApiOperation[] = [
     tags: ["Submission Checks"],
     summary: "Check shop URL availability",
     description:
-      "Checks whether a shop domain is unknown, already listed, previously rejected, queued for review, or invalid. Domain extraction uses the Public Suffix List via `tldts`.",
+      "Checks whether a shop domain is unknown, blocked by a managed domain alert, already listed, previously rejected, queued for review, or invalid. Domain extraction uses the Public Suffix List via `tldts`.",
     operationId: "checkShopUrl",
     parameters: [
       {

--- a/apps/backend/src/routes/public.ts
+++ b/apps/backend/src/routes/public.ts
@@ -153,6 +153,16 @@ publicRoutes.post(
           },
         });
       }
+      if (urlCheck.status === "blocked") {
+        c.status(409);
+        return c.json({
+          error: {
+            message: "Diese Shop-URL kann nicht eingereicht werden.",
+            status: "blocked",
+            messageMarkdown: urlCheck.messageMarkdown,
+          },
+        });
+      }
       if (urlCheck.status === "published") {
         c.status(409);
         return c.json({

--- a/apps/backend/src/services/admin-shops.ts
+++ b/apps/backend/src/services/admin-shops.ts
@@ -47,7 +47,7 @@ interface DeleteAdminShopData {
  * - `{ ok: false, reason: "domain_conflict", conflictStatus, conflictShopName }`
  *   when another shop or submission already claims the same registered domain.
  *   `conflictStatus` mirrors the `validateShopUrl` status (`"published"`,
- *   `"rejected"`, or `"pending"`).
+ *   `"rejected"`, `"pending"`, `"blocked"` or `"invalid"`).
  *
  * @remarks
  * Side effects on success:
@@ -61,7 +61,7 @@ export async function createManagedAdminShop(data: CreateAdminShopData) {
       ok: false as const,
       reason: "domain_conflict" as const,
       conflictStatus: urlCheck.status,
-      conflictShopName: urlCheck.shopName,
+      conflictShopName: "shopName" in urlCheck ? urlCheck.shopName : undefined,
     };
   }
 

--- a/apps/backend/src/services/domain-alert-rules.ts
+++ b/apps/backend/src/services/domain-alert-rules.ts
@@ -1,0 +1,88 @@
+import {
+  domainAlertRulesConfigSchema,
+  parseDomainAlertDomains,
+  type DomainAlertRule,
+  type DomainAlertRulesConfig,
+} from "@lmaa/contracts";
+import { SETTINGS_KEYS } from "@lmaa/shared";
+
+import { getSetting } from "../repositories/app-settings.js";
+
+const EMPTY_DOMAIN_ALERT_RULES_CONFIG: DomainAlertRulesConfig = { rules: [] };
+
+function normalizeHostname(input: string): string {
+  return input.trim().toLowerCase().replace(/^\.+|\.+$/g, "");
+}
+
+function getUrlHostname(urlRaw: string): string | null {
+  const trimmed = urlRaw.trim();
+  const input = trimmed.includes("://") ? trimmed : `https://${trimmed}`;
+
+  try {
+    return normalizeHostname(new URL(input).hostname);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Loads the managed submission domain alert config from app settings.
+ *
+ * @returns Persisted config, or an empty config when the setting is absent or invalid.
+ */
+export async function getManagedDomainAlertRulesConfig(): Promise<DomainAlertRulesConfig> {
+  const raw = await getSetting(SETTINGS_KEYS.DOMAIN_ALERT_RULES);
+  if (!raw) return EMPTY_DOMAIN_ALERT_RULES_CONFIG;
+
+  try {
+    const parsed = domainAlertRulesConfigSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : EMPTY_DOMAIN_ALERT_RULES_CONFIG;
+  } catch {
+    return EMPTY_DOMAIN_ALERT_RULES_CONFIG;
+  }
+}
+
+/**
+ * Checks whether one active domain alert rule matches a submitted hostname.
+ *
+ * @param hostname - Full normalized URL hostname, e.g. `www.example.de`.
+ * @param registeredDomain - Registered domain from `tldts`, e.g. `example.de`.
+ * @param rule - Configured rule to evaluate.
+ * @returns `true` when the hostname or registered domain matches the rule list.
+ */
+export function matchesDomainAlertRule(
+  hostname: string,
+  registeredDomain: string | null,
+  rule: DomainAlertRule,
+): boolean {
+  if (!rule.isActive) return false;
+
+  const configuredDomains = parseDomainAlertDomains(rule.domainsText);
+  const candidates = [hostname, registeredDomain]
+    .filter((candidate): candidate is string => Boolean(candidate))
+    .map(normalizeHostname);
+
+  return configuredDomains.some((domain) =>
+    candidates.some((candidate) => candidate === domain || candidate.endsWith(`.${domain}`)),
+  );
+}
+
+/**
+ * Finds the first active domain alert rule matching a submitted shop URL.
+ *
+ * @param urlRaw - Raw URL entered by a user.
+ * @param registeredDomain - Registered domain already extracted for duplicate checks.
+ * @returns The first matching rule, or `null` if no managed alert applies.
+ */
+export async function findMatchingDomainAlertRule(
+  urlRaw: string,
+  registeredDomain: string,
+): Promise<DomainAlertRule | null> {
+  const hostname = getUrlHostname(urlRaw);
+  if (!hostname) return null;
+
+  const config = await getManagedDomainAlertRulesConfig();
+  return (
+    config.rules.find((rule) => matchesDomainAlertRule(hostname, registeredDomain, rule)) ?? null
+  );
+}

--- a/apps/backend/src/services/public.ts
+++ b/apps/backend/src/services/public.ts
@@ -4,6 +4,7 @@ import { getDomain } from "tldts";
 
 import { encodeShopToken } from "@lmaa/shared";
 
+import { findMatchingDomainAlertRule } from "./domain-alert-rules.js";
 import { env } from "../config/env.js";
 import { extractEuropeanPostalCodePrefix } from "../lib/postal-code.js";
 import { type Result, failure, success } from "../lib/result.js";
@@ -58,49 +59,6 @@ const SHOPS_CACHE_TTL_MS = 60 * 1000;
 export function normalizeShopHostname(url: string): string | null {
   const input = url.includes("://") ? url : `https://${url}`;
   return getDomain(input) ?? null;
-}
-
-const AMAZON_STORE_DOMAINS = [
-  "amazon.com",
-  "amazon.ca",
-  "amazon.com.mx",
-  "amazon.com.br",
-  "amazon.co.uk",
-  "amazon.de",
-  "amazon.fr",
-  "amazon.it",
-  "amazon.es",
-  "amazon.nl",
-  "amazon.se",
-  "amazon.pl",
-  "amazon.com.tr",
-  "amazon.com.be",
-  "amazon.eg",
-  "amazon.sa",
-  "amazon.ae",
-  "amazon.in",
-  "amazon.com.au",
-  "amazon.co.jp",
-  "amazon.sg",
-  "amazon.cn",
-  "amazon.ie",
-  "amzn.to",
-  "amzn.eu",
-  "amzn.com",
-  "amzn.in",
-  "amzn.de",
-  "amzn.es",
-  "amzn.fr",
-  "amzn.it",
-  "amzn.uk",
-  "amzn.asia",
-] as const;
-
-const AMAZON_RICKROLL_URL = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
-
-export function isAmazonStoreHostname(hostname: string): boolean {
-  const lower = hostname.toLowerCase();
-  return AMAZON_STORE_DOMAINS.some((d) => lower === d || lower.endsWith(`.${d}`));
 }
 
 /**
@@ -318,11 +276,11 @@ export async function validateShopUrl(urlRaw: string | undefined) {
     return { status: "invalid" as const };
   }
 
-  if (isAmazonStoreHostname(domain)) {
+  const domainAlertRule = await findMatchingDomainAlertRule(url, domain);
+  if (domainAlertRule) {
     return {
-      status: "published" as const,
-      shopName: "Amazon",
-      shopUrl: AMAZON_RICKROLL_URL,
+      status: "blocked" as const,
+      messageMarkdown: domainAlertRule.messageMarkdown,
     };
   }
 

--- a/apps/dashboard/src/features/system/settings/DomainAlertsTab.tsx
+++ b/apps/dashboard/src/features/system/settings/DomainAlertsTab.tsx
@@ -1,0 +1,485 @@
+import {
+  PencilSimpleIcon,
+  PlusCircleIcon,
+  TrashIcon,
+  WarningCircleIcon,
+} from "@phosphor-icons/react";
+import { nanoid } from "nanoid";
+import { memo, Suspense, lazy, useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  domainAlertRuleSchema,
+  domainAlertRulesConfigSchema,
+  parseDomainAlertDomains,
+  type DomainAlertRule,
+  type DomainAlertRulesConfig,
+} from "@lmaa/contracts";
+import { SETTINGS_KEYS } from "@lmaa/shared";
+import { ToggleSwitch } from "@lmaa/ui";
+
+import { ContentUnavailableView } from "@/components/ui/ContentUnavailableView.tsx";
+import { dialogHeaderIconClass } from "@/components/ui/Dialog.tsx";
+import { OverlayCard } from "@/components/ui/OverlayCard.tsx";
+import { PageFooter } from "@/components/ui/PageFooter.tsx";
+import { type ColumnDef, DataTable } from "@/components/ui/Table.tsx";
+import { TableActionButton } from "@/components/ui/TableActionButton.tsx";
+import { useI18n } from "@/context/I18nContext.tsx";
+import {
+  fieldHintClass,
+  fieldLabelClass,
+  textAreaClass,
+  textInputClass,
+} from "@/features/system/widget-utils.ts";
+
+import { useSaveSystemSetting, useSystemSettings } from "./hooks/useSystemSettings.ts";
+
+const MarkdownEditor = lazy(() =>
+  import("@lmaa/ui").then((module) => ({ default: module.MarkdownEditor })),
+);
+
+interface DomainAlertsTabProps {
+  active: boolean;
+}
+
+type DomainAlertDialogTarget =
+  | { mode: "create"; rule: DomainAlertRule }
+  | { mode: "edit"; rule: DomainAlertRule };
+
+function parseStoredConfig(raw: string | undefined): DomainAlertRulesConfig {
+  if (!raw) return { rules: [] };
+  try {
+    const parsed = domainAlertRulesConfigSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : { rules: [] };
+  } catch {
+    return { rules: [] };
+  }
+}
+
+function serializeConfig(config: DomainAlertRulesConfig): string {
+  return JSON.stringify(config);
+}
+
+function createEmptyRule(name: string): DomainAlertRule {
+  return {
+    id: nanoid(),
+    name,
+    domainsText: "",
+    messageMarkdown: "",
+    isActive: true,
+  };
+}
+
+function Field({
+  label,
+  hint,
+  error,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  error?: string | null;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className={fieldLabelClass}>{label}</span>
+      {children}
+      {error ? (
+        <p className="px-1 text-xs leading-5 text-[var(--ds-danger-text)]">{error}</p>
+      ) : hint ? (
+        <p className={fieldHintClass}>{hint}</p>
+      ) : null}
+    </label>
+  );
+}
+
+function getRuleErrors(
+  rule: DomainAlertRule,
+  messages: ReturnType<typeof useI18n>["messages"]["system"]["settings"]["domainAlerts"],
+) {
+  const parsed = domainAlertRuleSchema.safeParse(rule);
+  const paths = parsed.success
+    ? new Set<string>()
+    : new Set(parsed.error.issues.map((issue) => String(issue.path[0])));
+
+  return {
+    name: paths.has("name") ? messages.nameRequired : null,
+    domains: paths.has("domainsText") ? messages.domainsRequired : null,
+    message: paths.has("messageMarkdown") ? messages.messageRequired : null,
+  };
+}
+
+interface DomainAlertRuleDialogProps {
+  target: DomainAlertDialogTarget | null;
+  onClose: () => void;
+  onSave: (target: DomainAlertDialogTarget) => Promise<boolean>;
+  isSaving: boolean;
+  saveError: string | null;
+}
+
+function DomainAlertRuleDialog({
+  target,
+  onClose,
+  onSave,
+  isSaving,
+  saveError,
+}: DomainAlertRuleDialogProps) {
+  const { messages } = useI18n();
+  const t = messages.system.settings.domainAlerts;
+  const common = messages.common;
+  const [draft, setDraft] = useState<DomainAlertRule | null>(target?.rule ?? null);
+  const [showValidationError, setShowValidationError] = useState(false);
+
+  useEffect(() => {
+    setDraft(target?.rule ?? null);
+    setShowValidationError(false);
+  }, [target]);
+
+  const handleSave = useCallback(async () => {
+    if (!target || !draft || isSaving) return;
+    const parsed = domainAlertRuleSchema.safeParse(draft);
+    if (!parsed.success) {
+      setShowValidationError(true);
+      return;
+    }
+
+    const nextTarget = { ...target, rule: draft } as DomainAlertDialogTarget;
+    const saved = await onSave(nextTarget);
+    if (saved) onClose();
+  }, [draft, isSaving, onClose, onSave, target]);
+
+  useEffect(() => {
+    if (!target) return;
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key.toLowerCase() !== "s" || (!event.metaKey && !event.ctrlKey)) return;
+
+      event.preventDefault();
+      void handleSave();
+    }
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [handleSave, target]);
+
+  if (!target || !draft) return null;
+
+  const errors = getRuleErrors(draft, t);
+  const displayName = draft.name.trim() || t.defaultName;
+  const titleTemplate = target.mode === "create" ? t.dialogCreateTitle : t.dialogEditTitle;
+  const title = titleTemplate.replace("{name}", displayName);
+
+  function updateDraft(patch: Partial<DomainAlertRule>) {
+    setDraft((current) => (current ? { ...current, ...patch } : current));
+  }
+
+  return (
+    <OverlayCard
+      open
+      onClose={onClose}
+      size={{ storageKey: "system:domain-alert-rule-editor", defaultWidth: 760, minWidth: 560 }}
+      aria-label={title}
+    >
+      <OverlayCard.Header>
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <WarningCircleIcon weight="duotone" className={dialogHeaderIconClass} />
+            <div className="min-w-0">
+              <h3 className="truncate font-bold text-[var(--ds-text)]">{title}</h3>
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <span className="text-sm text-[var(--ds-text-muted)]">{t.enabledLabel}</span>
+            <ToggleSwitch
+              checked={draft.isActive}
+              onChange={(checked) => updateDraft({ isActive: checked })}
+              aria-label={t.enabledLabel}
+            />
+          </div>
+        </div>
+      </OverlayCard.Header>
+
+      <OverlayCard.Body className="flex flex-col gap-5">
+        {showValidationError ? (
+          <div className="rounded-card border border-[var(--ds-warning-border)] bg-[var(--ds-warning-bg)] px-4 py-3 text-sm text-[var(--ds-warning-text)]">
+            {t.validationError}
+          </div>
+        ) : null}
+
+        {saveError ? (
+          <div className="rounded-card border border-[var(--ds-danger-border)] bg-[var(--ds-danger-bg)] px-4 py-3 text-sm text-[var(--ds-danger-text)]">
+            {saveError}
+          </div>
+        ) : null}
+
+        <Field label={t.nameLabel} error={showValidationError ? errors.name : null}>
+          <input
+            value={draft.name}
+            onChange={(event) => updateDraft({ name: event.target.value })}
+            className={textInputClass}
+          />
+        </Field>
+
+        <Field
+          label={t.domainsLabel}
+          hint={t.domainsHint}
+          error={showValidationError ? errors.domains : null}
+        >
+          <textarea
+            rows={4}
+            value={draft.domainsText}
+            onChange={(event) => updateDraft({ domainsText: event.target.value })}
+            className={`${textAreaClass} font-mono text-xs`}
+          />
+        </Field>
+
+        <Field
+          label={t.messageLabel}
+          hint={t.messageHint}
+          error={showValidationError ? errors.message : null}
+        >
+          <Suspense
+            fallback={
+              <div className="rounded-control border border-[var(--ds-border)] px-3 py-2 text-sm text-[var(--ds-text-muted)]">
+                {t.loadingEditor}
+              </div>
+            }
+          >
+            <MarkdownEditor
+              value={draft.messageMarkdown}
+              onChange={(value) => updateDraft({ messageMarkdown: value })}
+              rows={12}
+              resizable
+            />
+          </Suspense>
+        </Field>
+      </OverlayCard.Body>
+
+      <OverlayCard.Footer className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={isSaving}
+          className="h-9 px-4 border border-[var(--ds-border)] rounded-control text-sm text-[var(--ds-text-muted)] hover:border-[var(--ds-border-strong)]"
+        >
+          {common.cancel}
+        </button>
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={isSaving}
+          className="h-9 px-4 border border-[var(--ds-btn-primary-border)] text-[var(--ds-btn-primary-text)] rounded-control text-sm font-medium hover:border-[var(--ds-btn-primary-hover-border)] hover:bg-[var(--ds-btn-primary-hover-bg)] disabled:opacity-60"
+        >
+          {isSaving ? common.saving : target.mode === "create" ? t.createRule : t.saveRule}
+        </button>
+      </OverlayCard.Footer>
+    </OverlayCard>
+  );
+}
+
+export const DomainAlertsTab = memo(function DomainAlertsTab({ active }: DomainAlertsTabProps) {
+  const { messages } = useI18n();
+  const t = messages.system.settings.domainAlerts;
+  const common = messages.common;
+  const { data: settings } = useSystemSettings();
+  const saveSetting = useSaveSystemSetting();
+  const rawDomainAlertRulesSetting = settings?.[SETTINGS_KEYS.DOMAIN_ALERT_RULES];
+
+  const initialConfig = useMemo(
+    () => parseStoredConfig(rawDomainAlertRulesSetting),
+    [rawDomainAlertRulesSetting],
+  );
+  const [rules, setRules] = useState<DomainAlertRule[]>(initialConfig.rules);
+  const [dialogTarget, setDialogTarget] = useState<DomainAlertDialogTarget | null>(null);
+  const [showValidationError, setShowValidationError] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [savingDialog, setSavingDialog] = useState(false);
+  const [deletingRuleId, setDeletingRuleId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setRules(initialConfig.rules);
+    setDialogTarget(null);
+    setShowValidationError(false);
+    setSaveError(null);
+  }, [initialConfig]);
+
+  const persistRules = useCallback(async (nextRules: DomainAlertRule[]) => {
+    const parsed = domainAlertRulesConfigSchema.safeParse({ rules: nextRules });
+    if (!parsed.success) {
+      setShowValidationError(true);
+      return false;
+    }
+
+    try {
+      await saveSetting.mutateAsync({
+        key: SETTINGS_KEYS.DOMAIN_ALERT_RULES,
+        value: serializeConfig(parsed.data),
+      });
+      setRules(parsed.data.rules);
+      setShowValidationError(false);
+      setSaveError(null);
+      return true;
+    } catch {
+      setSaveError(t.saveError);
+      return false;
+    }
+  }, [saveSetting, t.saveError]);
+
+  const handleAddRule = useCallback(() => {
+    setDialogTarget({ mode: "create", rule: createEmptyRule(t.defaultName) });
+    setShowValidationError(false);
+    setSaveError(null);
+  }, [t.defaultName]);
+
+  const handleSaveRule = useCallback(async (target: DomainAlertDialogTarget) => {
+    const parsed = domainAlertRuleSchema.safeParse(target.rule);
+    if (!parsed.success) return false;
+
+    const nextRules =
+      target.mode === "create"
+        ? [...rules, parsed.data]
+        : rules.map((rule) => (rule.id === parsed.data.id ? parsed.data : rule));
+
+    setSavingDialog(true);
+    try {
+      return await persistRules(nextRules);
+    } finally {
+      setSavingDialog(false);
+    }
+  }, [persistRules, rules]);
+
+  const handleDeleteRule = useCallback(async (id: string) => {
+    const nextRules = rules.filter((rule) => rule.id !== id);
+    setDeletingRuleId(id);
+    try {
+      const saved = await persistRules(nextRules);
+      if (saved) {
+        setDialogTarget((current) => (current?.rule.id === id ? null : current));
+      }
+    } finally {
+      setDeletingRuleId(null);
+    }
+  }, [persistRules, rules]);
+
+  const columns: ColumnDef<DomainAlertRule>[] = useMemo(
+    () => [
+      {
+        id: "order",
+        headerClassName: "w-10",
+        cellClassName: "w-10 text-[var(--ds-text-muted)]",
+        cell: (row) => String(rules.findIndex((rule) => rule.id === row.id) + 1),
+      },
+      {
+        id: "name",
+        header: t.tableColumnName,
+        cell: (row) => (
+          <span className="font-medium text-[var(--ds-text)]">{row.name || t.defaultName}</span>
+        ),
+      },
+      {
+        id: "domains",
+        header: t.tableColumnDomains,
+        cell: (row) => {
+          const domains = parseDomainAlertDomains(row.domainsText);
+          return (
+            <span
+              className="block max-w-[38rem] truncate font-mono text-xs text-[var(--ds-text-muted)]"
+              title={domains.join(", ")}
+            >
+              {t.domainCountLabel.replace("{count}", String(domains.length))}
+              {domains.length > 0 ? ` · ${domains.join(", ")}` : ""}
+            </span>
+          );
+        },
+      },
+      {
+        id: "status",
+        header: t.tableColumnStatus,
+        cell: (row) => (
+          <span
+            className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+              row.isActive ? "bg-emerald-500/10 text-emerald-400" : "bg-stone-500/10 text-stone-400"
+            }`}
+          >
+            {row.isActive ? t.active : t.inactive}
+          </span>
+        ),
+      },
+      {
+        id: "actions",
+        header: t.tableColumnActions,
+        cellClassName: "text-right",
+        cell: (row) => (
+          <div className="flex items-center justify-end gap-2">
+            <TableActionButton
+              variant="neutral"
+              icon={<PencilSimpleIcon weight="duotone" className="w-3.5 h-3.5" />}
+              label={t.editRule}
+              onClick={() => {
+                setSaveError(null);
+                setDialogTarget({ mode: "edit", rule: { ...row } });
+              }}
+              disabled={savingDialog || deletingRuleId !== null}
+            />
+            <TableActionButton
+              variant="danger"
+              icon={<TrashIcon weight="duotone" className="w-3.5 h-3.5" />}
+              label={deletingRuleId === row.id ? common.saving : t.deleteRule}
+              onClick={() => void handleDeleteRule(row.id)}
+              disabled={savingDialog || deletingRuleId !== null}
+            />
+          </div>
+        ),
+      },
+    ],
+    [common.saving, deletingRuleId, handleDeleteRule, rules, savingDialog, t],
+  );
+
+  return (
+    <div className="space-y-3">
+      {showValidationError ? (
+        <div className="rounded-card border border-[var(--ds-warning-border)] bg-[var(--ds-warning-bg)] px-4 py-3 text-sm text-[var(--ds-warning-text)]">
+          {t.validationError}
+        </div>
+      ) : null}
+
+      {saveError && !dialogTarget ? (
+        <div className="rounded-card border border-[var(--ds-danger-border)] bg-[var(--ds-danger-bg)] px-4 py-3 text-sm text-[var(--ds-danger-text)]">
+          {saveError}
+        </div>
+      ) : null}
+
+      {rules.length === 0 ? (
+        <ContentUnavailableView
+          chromeless
+          icon={<WarningCircleIcon weight="duotone" aria-hidden />}
+          title={t.emptyTitle}
+          subtitle={t.emptyHint}
+        />
+      ) : (
+        <DataTable columns={columns} data={rules} getRowKey={(rule) => rule.id} stickyHeader />
+      )}
+
+      {active ? (
+        <PageFooter>
+          <button
+            type="button"
+            onClick={handleAddRule}
+            className="flex h-9 items-center gap-1.5 rounded-control border border-[var(--ds-btn-primary-border)] px-3 text-sm font-medium text-[var(--ds-btn-primary-text)] hover:border-[var(--ds-btn-primary-hover-border)] hover:bg-[var(--ds-btn-primary-hover-bg)]"
+          >
+            <PlusCircleIcon weight="duotone" className="w-3.5 h-3.5" />
+            {t.newRule}
+          </button>
+        </PageFooter>
+      ) : null}
+
+      <DomainAlertRuleDialog
+        target={dialogTarget}
+        onClose={() => setDialogTarget(null)}
+        onSave={handleSaveRule}
+        isSaving={savingDialog}
+        saveError={saveError}
+      />
+    </div>
+  );
+});

--- a/apps/dashboard/src/features/system/settings/NotificationsTab.tsx
+++ b/apps/dashboard/src/features/system/settings/NotificationsTab.tsx
@@ -1,134 +1,169 @@
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { BellIcon, FloppyDiskIcon } from "@phosphor-icons/react";
+import { memo, useCallback, useMemo, useState } from "react";
 
 import { SETTINGS_KEYS } from "@lmaa/shared";
-import { ToggleSwitch } from "@lmaa/ui";
+import { DashboardSection, ToggleSwitch } from "@lmaa/ui";
 
 import { useI18n } from "@/context/I18nContext.tsx";
 import { useEmailTemplates } from "@/features/templates/hooks/useEmailTemplates.ts";
 
-import {
-  useSaveSystemSetting,
-  useSystemSettings,
-} from "./hooks/useSystemSettings.ts";
+import { useSaveSystemSetting, useSystemSettings } from "./hooks/useSystemSettings.ts";
 
-const cardClass =
-  "rounded-card border border-[var(--ds-border-subtle)] bg-[var(--ds-surface)] divide-y divide-[var(--ds-border-subtle)]";
-const rowClass = "flex items-center justify-between gap-4 px-4 py-3";
 const rowLabelClass = "text-sm font-medium text-[var(--ds-text)]";
-const rowSubtitleClass = "text-xs text-[var(--ds-text-muted)] mt-0.5";
 const selectClass =
   "h-9 px-3 pr-8 rounded-control border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)] text-sm text-[var(--ds-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]";
-const hintClass = "mt-2 text-xs text-[var(--ds-text-muted)] px-1";
 
-interface NotificationsTabProps {
-  onDirtyChange: (dirty: boolean) => void;
-  registerSaver: (save: () => Promise<void>) => void;
+interface NotificationDraftState {
+  baselineEnabled: boolean;
+  baselineTemplateId: string;
+  enabled: boolean;
+  templateId: string;
 }
 
-export const NotificationsTab = memo(function NotificationsTab({
-  onDirtyChange,
-  registerSaver,
-}: NotificationsTabProps) {
+function createNotificationDraft(
+  baselineEnabled: boolean,
+  baselineTemplateId: string,
+): NotificationDraftState {
+  return {
+    baselineEnabled,
+    baselineTemplateId,
+    enabled: baselineEnabled,
+    templateId: baselineTemplateId,
+  };
+}
+
+export const NotificationsTab = memo(function NotificationsTab() {
   const { messages } = useI18n();
+  const common = messages.common;
   const t = messages.system.settings.newShopSubmission;
 
   const { data: settings } = useSystemSettings();
   const { data: templates, isLoading: templatesLoading } = useEmailTemplates();
   const saveSetting = useSaveSystemSetting();
 
-  const initialEnabled =
-    settings?.[SETTINGS_KEYS.NOTIFY_SHOP_SUBMISSION_ENABLED] === "true";
-  const initialTemplateId =
-    settings?.[SETTINGS_KEYS.NOTIFY_SHOP_SUBMISSION_TEMPLATE_ID] ?? "";
+  const initialEnabled = settings?.[SETTINGS_KEYS.NOTIFY_SHOP_SUBMISSION_ENABLED] === "true";
+  const initialTemplateId = settings?.[SETTINGS_KEYS.NOTIFY_SHOP_SUBMISSION_TEMPLATE_ID] ?? "";
 
-  const [enabled, setEnabled] = useState(initialEnabled);
-  const [templateId, setTemplateId] = useState(initialTemplateId);
+  const [draft, setDraft] = useState(() =>
+    createNotificationDraft(initialEnabled, initialTemplateId),
+  );
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
-  useEffect(() => {
-    setEnabled(initialEnabled);
-    setTemplateId(initialTemplateId);
-  }, [initialEnabled, initialTemplateId]);
+  const baselineChanged =
+    draft.baselineEnabled !== initialEnabled || draft.baselineTemplateId !== initialTemplateId;
+  const currentDraft = baselineChanged
+    ? createNotificationDraft(initialEnabled, initialTemplateId)
+    : draft;
+
+  if (baselineChanged) {
+    setDraft(currentDraft);
+  }
+
+  const { enabled, templateId } = currentDraft;
 
   const dirty = useMemo(
-    () => enabled !== initialEnabled || templateId !== initialTemplateId,
-    [enabled, templateId, initialEnabled, initialTemplateId],
+    () =>
+      currentDraft.enabled !== currentDraft.baselineEnabled ||
+      currentDraft.templateId !== currentDraft.baselineTemplateId,
+    [currentDraft],
   );
-
-  useEffect(() => {
-    onDirtyChange(dirty);
-  }, [dirty, onDirtyChange]);
 
   const save = useCallback(async () => {
     const nextEnabled = enabled && templateId !== "" ? "true" : "false";
-    await Promise.all([
-      saveSetting.mutateAsync({
-        key: SETTINGS_KEYS.NOTIFY_SHOP_SUBMISSION_ENABLED,
-        value: nextEnabled,
-      }),
-      saveSetting.mutateAsync({
-        key: SETTINGS_KEYS.NOTIFY_SHOP_SUBMISSION_TEMPLATE_ID,
-        value: templateId,
-      }),
-    ]);
-  }, [enabled, templateId, saveSetting]);
-
-  useEffect(() => {
-    registerSaver(save);
-  }, [save, registerSaver]);
+    setSaving(true);
+    try {
+      await Promise.all([
+        saveSetting.mutateAsync({
+          key: SETTINGS_KEYS.NOTIFY_SHOP_SUBMISSION_ENABLED,
+          value: nextEnabled,
+        }),
+        saveSetting.mutateAsync({
+          key: SETTINGS_KEYS.NOTIFY_SHOP_SUBMISSION_TEMPLATE_ID,
+          value: templateId,
+        }),
+      ]);
+      setSaveError(null);
+    } catch {
+      setSaveError(common.unknownError);
+    } finally {
+      setSaving(false);
+    }
+  }, [common.unknownError, enabled, templateId, saveSetting]);
 
   const canEnable = templateId !== "";
   const handleToggle = useCallback(
     (next: boolean) => {
-      if (next && !canEnable) return;
-      setEnabled(next);
+      if (saving || (next && !canEnable)) return;
+      setDraft((current) => ({ ...current, enabled: next }));
     },
-    [canEnable],
+    [canEnable, saving],
   );
 
   const handleTemplateChange = useCallback((id: string) => {
-    setTemplateId(id);
-    if (id === "") setEnabled(false);
+    setDraft((current) => ({
+      ...current,
+      enabled: id === "" ? false : current.enabled,
+      templateId: id,
+    }));
   }, []);
 
   return (
     <div className="max-w-xl">
-      <div className={cardClass}>
-        <div className={rowClass}>
-          <div className="min-w-0">
-            <p className={rowLabelClass}>{t.title}</p>
-            <p className={rowSubtitleClass}>{t.recipientLabel}: OWNER_EMAIL</p>
-          </div>
-          <ToggleSwitch
-            checked={enabled}
-            onChange={handleToggle}
-            disabled={!canEnable && !enabled}
-          />
-        </div>
-        <div className={rowClass}>
-          <label htmlFor="shop-submission-template" className={rowLabelClass}>
-            {t.templateLabel}
-          </label>
-          <select
-            id="shop-submission-template"
-            value={templateId}
-            onChange={(e) => handleTemplateChange(e.target.value)}
-            disabled={templatesLoading}
-            className={selectClass}
-          >
-            <option value="">
-              {templatesLoading ? t.templateLoading : t.templatePlaceholder}
-            </option>
-            {templates?.map((tmpl) => (
-              <option key={tmpl.id} value={String(tmpl.id)}>
-                {tmpl.name}
+      <DashboardSection>
+        <DashboardSection.Header
+          icon={<BellIcon weight="duotone" className="size-4" />}
+          title={t.title}
+          subtitle={`${t.recipientLabel}: OWNER_EMAIL`}
+          addOn={
+            <ToggleSwitch
+              checked={enabled}
+              onChange={handleToggle}
+              disabled={saving || (!canEnable && !enabled)}
+            />
+          }
+        />
+        <DashboardSection.Body>
+          <div className="flex items-center justify-between gap-4">
+            <label htmlFor="shop-submission-template" className={rowLabelClass}>
+              {t.templateLabel}
+            </label>
+            <select
+              id="shop-submission-template"
+              value={templateId}
+              onChange={(e) => handleTemplateChange(e.target.value)}
+              disabled={templatesLoading || saving}
+              className={selectClass}
+            >
+              <option value="">
+                {templatesLoading ? t.templateLoading : t.templatePlaceholder}
               </option>
-            ))}
-          </select>
-        </div>
-      </div>
-      <p className={hintClass}>
-        {canEnable ? t.hint : t.requireTemplateHint}
-      </p>
+              {templates?.map((tmpl) => (
+                <option key={tmpl.id} value={String(tmpl.id)}>
+                  {tmpl.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          {saveError ? (
+            <p className="mt-3 text-xs text-[var(--ds-danger-text)]">{saveError}</p>
+          ) : null}
+        </DashboardSection.Body>
+        <DashboardSection.Footer className="flex flex-wrap items-center justify-between gap-3">
+          <span className="min-w-0 flex-1 text-xs text-[var(--ds-text-muted)]">
+            {canEnable ? t.hint : t.requireTemplateHint}
+          </span>
+          <button
+            type="button"
+            onClick={() => void save()}
+            disabled={!dirty || saving}
+            className="flex h-9 items-center gap-1.5 rounded-control border border-[var(--ds-btn-primary-border)] px-3 text-sm font-medium text-[var(--ds-btn-primary-text)] hover:border-[var(--ds-btn-primary-hover-border)] hover:bg-[var(--ds-btn-primary-hover-bg)] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <FloppyDiskIcon weight="duotone" className="size-3.5" />
+            {saving ? common.saving : common.save}
+          </button>
+        </DashboardSection.Footer>
+      </DashboardSection>
     </div>
   );
 });

--- a/apps/dashboard/src/features/system/settings/SystemSettingsPage.tsx
+++ b/apps/dashboard/src/features/system/settings/SystemSettingsPage.tsx
@@ -1,12 +1,12 @@
-import { FloppyDiskIcon } from "@phosphor-icons/react";
-import { useCallback, useRef, useState } from "react";
+import { useState } from "react";
 
-import { TabContent, TabList, TabTrigger, Tabs } from "@lmaa/ui";
+import { TabList, TabTrigger, Tabs } from "@lmaa/ui";
 
 import { PageHeader } from "@/components/ui/PageHeader.tsx";
 import { PageLayout } from "@/components/ui/PageLayout.tsx";
 import { useI18n } from "@/context/I18nContext.tsx";
 
+import { DomainAlertsTab } from "./DomainAlertsTab.tsx";
 import { NotificationsTab } from "./NotificationsTab.tsx";
 
 export function SystemSettingsPage() {
@@ -14,47 +14,30 @@ export function SystemSettingsPage() {
   const t = messages.system.settings;
 
   const [activeTab, setActiveTab] = useState("notifications");
-  const [dirty, setDirty] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const saverRef = useRef<(() => Promise<void>) | null>(null);
-
-  const registerSaver = useCallback((save: () => Promise<void>) => {
-    saverRef.current = save;
-  }, []);
-
-  const handleSave = useCallback(async () => {
-    if (!saverRef.current || !dirty) return;
-    setSaving(true);
-    try {
-      await saverRef.current();
-      setDirty(false);
-    } finally {
-      setSaving(false);
-    }
-  }, [dirty]);
 
   return (
     <PageLayout>
-      <PageHeader title={t.title}>
-        <button
-          type="button"
-          onClick={handleSave}
-          disabled={!dirty || saving}
-          className="h-9 px-3 flex items-center gap-1.5 rounded-control border border-[var(--ds-btn-primary-border)] text-[var(--ds-btn-primary-text)] text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:border-[var(--ds-btn-primary-hover-border)] hover:bg-[var(--ds-btn-primary-hover-bg)]"
-        >
-          <FloppyDiskIcon weight="duotone" className="w-3.5 h-3.5" />
-          {saving ? messages.common.saving : messages.common.save}
-        </button>
-      </PageHeader>
+      <PageHeader title={t.title} />
 
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabList>
           <TabTrigger value="notifications">{t.notificationsTab}</TabTrigger>
+          <TabTrigger value="domainAlerts">{t.domainAlertsTab}</TabTrigger>
         </TabList>
 
-        <TabContent value="notifications" className="pt-6">
-          <NotificationsTab onDirtyChange={setDirty} registerSaver={registerSaver} />
-        </TabContent>
+        <div
+          role="tabpanel"
+          className={activeTab === "notifications" ? "pt-6" : "hidden"}
+        >
+          <NotificationsTab />
+        </div>
+
+        <div
+          role="tabpanel"
+          className={activeTab === "domainAlerts" ? "pt-6" : "hidden"}
+        >
+          <DomainAlertsTab active={activeTab === "domainAlerts"} />
+        </div>
       </Tabs>
     </PageLayout>
   );

--- a/apps/dashboard/src/i18n/messages.ts
+++ b/apps/dashboard/src/i18n/messages.ts
@@ -1092,6 +1092,7 @@ export interface DashboardMessages {
     settings: {
       title: string;
       notificationsTab: string;
+      domainAlertsTab: string;
       newShopSubmission: {
         title: string;
         recipientLabel: string;
@@ -1101,6 +1102,42 @@ export interface DashboardMessages {
         templateLoading: string;
         hint: string;
         requireTemplateHint: string;
+      };
+      domainAlerts: {
+        title: string;
+        hint: string;
+        newRule: string;
+        emptyTitle: string;
+        emptyHint: string;
+        active: string;
+        inactive: string;
+        defaultName: string;
+        nameLabel: string;
+        domainsLabel: string;
+        domainsHint: string;
+        messageLabel: string;
+        messageHint: string;
+        enabledLabel: string;
+        deleteRule: string;
+        editRule: string;
+        noSelection: string;
+        validationError: string;
+        nameRequired: string;
+        domainsRequired: string;
+        messageRequired: string;
+        domainCountLabel: string;
+        moveUp: string;
+        moveDown: string;
+        loadingEditor: string;
+        createRule: string;
+        saveRule: string;
+        saveError: string;
+        dialogCreateTitle: string;
+        dialogEditTitle: string;
+        tableColumnName: string;
+        tableColumnDomains: string;
+        tableColumnStatus: string;
+        tableColumnActions: string;
       };
     };
     backgroundErrors: {
@@ -1717,8 +1754,7 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
         iconsLabel: "Icons (Reihenfolge per Drag)",
         iconsEmpty:
           'Keine Footer-fähigen Accounts. Lege unter Social Media einen an und aktiviere „Im Footer anzeigen".',
-        spacerHint:
-          "Schiebt nachfolgende Blöcke in der Spalte ans Ende — wie ein SwiftUI-Spacer.",
+        spacerHint: "Schiebt nachfolgende Blöcke in der Spalte ans Ende — wie ein SwiftUI-Spacer.",
         styleOptions: {
           filled: "Gefüllt",
           outline: "Outline",
@@ -2183,13 +2219,15 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
       title: "Social Media Accounts",
       editAccount: "Account bearbeiten",
       noAccounts: "Keine Accounts konfiguriert.",
-      noAccountsHint: "Hinterlege einen Social Media Account für Footer-Links oder automatische Postings.",
+      noAccountsHint:
+        "Hinterlege einen Social Media Account für Footer-Links oder automatische Postings.",
       tokenStored: "Token hinterlegt",
       tokenMissing: "Kein Token",
       tokenRequired: "Bitte einen Access Token hinterlegen.",
       saveError: "Fehler beim Speichern.",
       tokenInvalid: "Der Access Token wurde von der Mastodon-Instanz abgelehnt.",
-      instanceUnreachable: "Die Mastodon-Instanz ist nicht erreichbar. Bitte die Instanz-URL prüfen.",
+      instanceUnreachable:
+        "Die Mastodon-Instanz ist nicht erreichbar. Bitte die Instanz-URL prüfen.",
       deleteAccount: "Account löschen?",
       deleteConfirm: "Diesen Account wirklich löschen?",
       accessTokenPlaceholder: "Mastodon User Access Token",
@@ -2242,8 +2280,7 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
         handleLabel: "Handle oder Email",
         appPasswordLabel: "Passwort",
         appPasswordKeepHint: "leer lassen, um das aktuelle Passwort zu behalten",
-        appPasswordRecommendation:
-          "App-Passwort empfohlen — sicherer und 2FA-kompatibel.",
+        appPasswordRecommendation: "App-Passwort empfohlen — sicherer und 2FA-kompatibel.",
         appPasswordSettingsLink: "App-Passwort in BlueSky erstellen",
         activeLabel: "Aktiv",
         conflictError: "Ein BlueSky Account ist bereits konfiguriert.",
@@ -2263,6 +2300,7 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
       settings: {
         title: "Einstellungen",
         notificationsTab: "Benachrichtigungen",
+        domainAlertsTab: "Domain-Alerts",
         newShopSubmission: {
           title: "Neuer Shop-Vorschlag",
           recipientLabel: "Empfänger",
@@ -2273,6 +2311,42 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
           hint: "Wird verschickt, sobald ein neuer Shop-Vorschlag eingeht.",
           requireTemplateHint:
             "Bitte zuerst ein Template wählen, um die Benachrichtigung zu aktivieren.",
+        },
+        domainAlerts: {
+          title: "Submission Domain-Alerts",
+          hint: "Aktive Regeln werden vor der normalen Duplikatprüfung der Reihe nach gegen die eingereichte Shop-Domain geprüft.",
+          newRule: "Neuer Domain-Alert",
+          emptyTitle: "Noch keine Regeln.",
+          emptyHint: "Lege die erste Domainliste mit zugehöriger Markdown-Meldung an.",
+          active: "aktiv",
+          inactive: "aus",
+          defaultName: "Neue Domain-Regel",
+          nameLabel: "Name",
+          domainsLabel: "Domains",
+          domainsHint: "Kommagetrennt, z.B. amazon.de, amazon.com, amzn.to",
+          messageLabel: "Meldung",
+          messageHint: "Diese Markdown-Meldung erscheint im öffentlichen Formular als Alert.",
+          enabledLabel: "Aktiviert",
+          deleteRule: "Löschen",
+          editRule: "Bearbeiten",
+          noSelection: "Wähle links eine Regel oder lege eine neue an.",
+          validationError: "Bitte prüfe die markierten Angaben vor dem Speichern.",
+          nameRequired: "Bitte einen Namen angeben.",
+          domainsRequired: "Bitte mindestens eine gültige Domain angeben.",
+          messageRequired: "Bitte eine Markdown-Meldung angeben.",
+          domainCountLabel: "{count} Domains",
+          moveUp: "Nach oben",
+          moveDown: "Nach unten",
+          loadingEditor: "Editor lädt…",
+          createRule: "Anlegen",
+          saveRule: "Speichern",
+          saveError: "Fehler beim Speichern. Bitte erneut versuchen.",
+          dialogCreateTitle: "{name} anlegen",
+          dialogEditTitle: "{name} bearbeiten",
+          tableColumnName: "Name",
+          tableColumnDomains: "Domains",
+          tableColumnStatus: "Status",
+          tableColumnActions: "",
         },
       },
       backgroundErrors: {
@@ -3402,8 +3476,7 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
         handleLabel: "Handle or email",
         appPasswordLabel: "Password",
         appPasswordKeepHint: "leave empty to keep the current password",
-        appPasswordRecommendation:
-          "App password recommended — safer and 2FA-compatible.",
+        appPasswordRecommendation: "App password recommended — safer and 2FA-compatible.",
         appPasswordSettingsLink: "Create an app password on BlueSky",
         activeLabel: "Active",
         conflictError: "A BlueSky account is already configured.",
@@ -3423,6 +3496,7 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
       settings: {
         title: "Settings",
         notificationsTab: "Notifications",
+        domainAlertsTab: "Domain Alerts",
         newShopSubmission: {
           title: "New shop suggestion",
           recipientLabel: "Recipient",
@@ -3432,6 +3506,42 @@ export const DASHBOARD_MESSAGES: Record<DashboardLocale, DashboardMessages> = {
           templateLoading: "Loading templates…",
           hint: "Sent whenever a new shop suggestion arrives.",
           requireTemplateHint: "Pick a template first to enable the notification.",
+        },
+        domainAlerts: {
+          title: "Submission Domain Alerts",
+          hint: "Active rules are checked in order against the submitted shop domain before the normal duplicate lookup.",
+          newRule: "New Domain Alert",
+          emptyTitle: "No rules yet.",
+          emptyHint: "Create the first domain list with its markdown message.",
+          active: "active",
+          inactive: "off",
+          defaultName: "New domain rule",
+          nameLabel: "Name",
+          domainsLabel: "Domains",
+          domainsHint: "Comma-separated, e.g. amazon.de, amazon.com, amzn.to",
+          messageLabel: "Message",
+          messageHint: "This markdown message appears as an alert in the public form.",
+          enabledLabel: "Enabled",
+          deleteRule: "Delete",
+          editRule: "Edit",
+          noSelection: "Select a rule on the left or create a new one.",
+          validationError: "Please check the highlighted fields before saving.",
+          nameRequired: "Please enter a name.",
+          domainsRequired: "Please enter at least one valid domain.",
+          messageRequired: "Please enter a markdown message.",
+          domainCountLabel: "{count} domains",
+          moveUp: "Move up",
+          moveDown: "Move down",
+          loadingEditor: "Loading editor…",
+          createRule: "Create",
+          saveRule: "Save",
+          saveError: "Error saving. Please try again.",
+          dialogCreateTitle: "Create {name}",
+          dialogEditTitle: "Edit {name}",
+          tableColumnName: "Name",
+          tableColumnDomains: "Domains",
+          tableColumnStatus: "Status",
+          tableColumnActions: "",
         },
       },
       backgroundErrors: {

--- a/apps/frontend/src/components/islands/DynamicForm.tsx
+++ b/apps/frontend/src/components/islands/DynamicForm.tsx
@@ -129,7 +129,10 @@ export default function DynamicForm({ formConfig: rawFormConfig, categories }: P
           const errorObj = error && typeof error === "object" ? (error as Record<string, unknown>) : null;
           const rawStatus = errorObj?.status;
           const status =
-            rawStatus === "published" || rawStatus === "rejected" || rawStatus === "pending"
+            rawStatus === "published" ||
+            rawStatus === "rejected" ||
+            rawStatus === "pending" ||
+            rawStatus === "blocked"
               ? rawStatus
               : undefined;
           dispatch({
@@ -143,6 +146,10 @@ export default function DynamicForm({ formConfig: rawFormConfig, categories }: P
               shopUrl: typeof errorObj?.shopUrl === "string" ? errorObj.shopUrl : undefined,
               rejectionUrl:
                 typeof errorObj?.rejectionUrl === "string" ? errorObj.rejectionUrl : undefined,
+              messageMarkdown:
+                typeof errorObj?.messageMarkdown === "string"
+                  ? errorObj.messageMarkdown
+                  : undefined,
             },
           });
           return;
@@ -218,6 +225,7 @@ export default function DynamicForm({ formConfig: rawFormConfig, categories }: P
                 shopName: result.shopName,
                 shopUrl: result.shopUrl,
                 rejectionUrl: result.rejectionUrl,
+                messageMarkdown: result.messageMarkdown,
               },
             })
           }

--- a/apps/frontend/src/components/islands/DynamicFormFields.tsx
+++ b/apps/frontend/src/components/islands/DynamicFormFields.tsx
@@ -638,10 +638,11 @@ function RichTextBlock({ field }: { field: FormField }) {
 }
 
 export interface CheckShopResult {
-  status: "available" | "published" | "rejected" | "pending" | "invalid";
+  status: "available" | "published" | "rejected" | "pending" | "invalid" | "blocked";
   shopName?: string;
   shopUrl?: string;
   rejectionUrl?: string;
+  messageMarkdown?: string;
 }
 
 interface ButtonFieldProps {
@@ -713,7 +714,8 @@ function ButtonField({
             status !== "published" &&
             status !== "pending" &&
             status !== "rejected" &&
-            status !== "invalid"
+            status !== "invalid" &&
+            status !== "blocked"
           ) {
             return;
           }
@@ -722,6 +724,8 @@ function ButtonField({
             shopName: typeof data?.shopName === "string" ? data.shopName : undefined,
             shopUrl: typeof data?.shopUrl === "string" ? data.shopUrl : undefined,
             rejectionUrl: typeof data?.rejectionUrl === "string" ? data.rejectionUrl : undefined,
+            messageMarkdown:
+              typeof data?.messageMarkdown === "string" ? data.messageMarkdown : undefined,
           });
         } catch {
           // Users can retry the explicit availability check after transient network failures.

--- a/apps/frontend/src/components/islands/DynamicFormSubmitErrorDialog.tsx
+++ b/apps/frontend/src/components/islands/DynamicFormSubmitErrorDialog.tsx
@@ -1,11 +1,14 @@
 import { AlertDialog } from "@lmaa/ui";
 
+import { useMarkdownHtml } from "@/hooks/useMarkdownHtml";
+
 export interface SubmitErrorState {
   message: string;
-  status?: "published" | "rejected" | "pending" | "available" | "invalid";
+  status?: "published" | "rejected" | "pending" | "available" | "invalid" | "blocked";
   shopName?: string;
   shopUrl?: string;
   rejectionUrl?: string;
+  messageMarkdown?: string;
 }
 
 function PublishedShopName({ name, url }: { name: string | undefined; url: string | undefined }) {
@@ -20,6 +23,21 @@ function PublishedShopName({ name, url }: { name: string | undefined; url: strin
     >
       {name}
     </a>
+  );
+}
+
+function BlockedMessage({ messageMarkdown, fallback }: { messageMarkdown?: string; fallback: string }) {
+  const messageRef = useMarkdownHtml(messageMarkdown);
+
+  if (!messageMarkdown) {
+    return <p>{fallback}</p>;
+  }
+
+  return (
+    <div
+      ref={messageRef}
+      className="prose prose-sm max-w-none text-[var(--ds-text)] [&_p]:m-0 [&_p+p]:mt-3 prose-a:text-[var(--ds-accent)] prose-a:underline hover:prose-a:no-underline"
+    />
   );
 }
 
@@ -40,6 +58,8 @@ export function SubmitErrorDialog({ submitError, onClose }: SubmitErrorDialogPro
           ? "Shop abgelehnt"
           : submitError?.status === "pending"
             ? "Shop wird bereits geprüft"
+            : submitError?.status === "blocked"
+              ? "Hinweis"
             : submitError?.status === "available"
               ? "Shop ist verfügbar"
               : submitError?.status === "invalid"
@@ -49,6 +69,8 @@ export function SubmitErrorDialog({ submitError, onClose }: SubmitErrorDialogPro
       variant={
         submitError?.status === "rejected"
           ? "warning"
+          : submitError?.status === "blocked"
+            ? "warning"
           : submitError?.status === "available"
             ? "info"
             : "error"
@@ -56,7 +78,12 @@ export function SubmitErrorDialog({ submitError, onClose }: SubmitErrorDialogPro
       buttonLabel="Verstanden"
       onClose={onClose}
     >
-      {submitError?.status === "invalid" ? (
+      {submitError?.status === "blocked" ? (
+        <BlockedMessage
+          messageMarkdown={submitError.messageMarkdown}
+          fallback={submitError.message}
+        />
+      ) : submitError?.status === "invalid" ? (
         <p>
           Bitte eine gültige Shop-URL eingeben (z.B. <code>example.de</code>).
         </p>

--- a/packages/contracts/src/domain-alert-rules.ts
+++ b/packages/contracts/src/domain-alert-rules.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+
+/** Maximum number of configurable submission domain alert rules. */
+export const DOMAIN_ALERT_RULES_MAX = 50;
+
+/** Maximum length for the comma-separated domains field of one rule. */
+export const DOMAIN_ALERT_DOMAINS_MAX_LENGTH = 4000;
+
+/** Maximum length for the markdown alert message of one rule. */
+export const DOMAIN_ALERT_MESSAGE_MAX_LENGTH = 5000;
+
+function normalizeDomainAlertDomain(input: string): string {
+  const withoutScheme = input.trim().toLowerCase().replace(/^https?:\/\//, "");
+  const host = withoutScheme.split(/[/?#]/, 1)[0] ?? "";
+  return host.replace(/^\.+|\.+$/g, "");
+}
+
+function isLikelyDomain(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value.length <= 253 &&
+    value.includes(".") &&
+    !/[\s:]/.test(value)
+  );
+}
+
+/**
+ * Parses a comma-separated domain list from the admin UI.
+ *
+ * @param domainsText - Raw comma-separated domain list.
+ * @returns Lowercase, de-duplicated domain names without URL paths or schemes.
+ */
+export function parseDomainAlertDomains(domainsText: string): string[] {
+  const seen = new Set<string>();
+  const domains: string[] = [];
+
+  for (const entry of domainsText.split(/[,\n]/)) {
+    const domain = normalizeDomainAlertDomain(entry);
+    if (!domain || seen.has(domain)) continue;
+    seen.add(domain);
+    domains.push(domain);
+  }
+
+  return domains;
+}
+
+/**
+ * Schema for one configurable submission domain alert rule.
+ */
+export const domainAlertRuleSchema = z
+  .object({
+    id: z.string().trim().min(1).max(100),
+    name: z.string().trim().min(1).max(120),
+    domainsText: z.string().max(DOMAIN_ALERT_DOMAINS_MAX_LENGTH),
+    messageMarkdown: z.string().max(DOMAIN_ALERT_MESSAGE_MAX_LENGTH),
+    isActive: z.boolean().default(true),
+  })
+  .superRefine((rule, ctx) => {
+    const domains = parseDomainAlertDomains(rule.domainsText);
+    if (domains.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["domainsText"],
+        message: "At least one domain is required.",
+      });
+    }
+
+    const invalidDomain = domains.find((domain) => !isLikelyDomain(domain));
+    if (invalidDomain) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["domainsText"],
+        message: `Invalid domain: ${invalidDomain}`,
+      });
+    }
+
+    if (rule.messageMarkdown.trim().length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["messageMarkdown"],
+        message: "A markdown message is required.",
+      });
+    }
+  });
+
+/**
+ * Config schema for all configurable submission domain alert rules.
+ */
+export const domainAlertRulesConfigSchema = z.object({
+  rules: z.array(domainAlertRuleSchema).max(DOMAIN_ALERT_RULES_MAX),
+});
+
+/** One configurable submission domain alert rule. */
+export type DomainAlertRule = z.infer<typeof domainAlertRuleSchema>;
+
+/** Persisted config for all configurable submission domain alert rules. */
+export type DomainAlertRulesConfig = z.infer<typeof domainAlertRulesConfigSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -32,3 +32,5 @@ export * from "./admin-form-config";
 export * from "./footer-config";
 /** Admin markdown widget schemas. */
 export * from "./admin-markdown-widgets";
+/** Submission domain alert rule schemas. */
+export * from "./domain-alert-rules";

--- a/packages/shared/src/constants/settings.ts
+++ b/packages/shared/src/constants/settings.ts
@@ -4,6 +4,7 @@
 export const SETTINGS_KEYS = {
   NOTIFY_SHOP_SUBMISSION_ENABLED: "notifications.newShopSubmission.enabled",
   NOTIFY_SHOP_SUBMISSION_TEMPLATE_ID: "notifications.newShopSubmission.templateId",
+  DOMAIN_ALERT_RULES: "submission.domainAlertRules",
 } as const;
 
 export type SettingsKey = (typeof SETTINGS_KEYS)[keyof typeof SETTINGS_KEYS];
@@ -14,5 +15,11 @@ export const SYSTEM_NOTIFICATION_SETTINGS_KEYS = [
   SETTINGS_KEYS.NOTIFY_SHOP_SUBMISSION_TEMPLATE_ID,
 ] as const;
 
+/** Submission-related system settings keys. */
+export const SYSTEM_SUBMISSION_SETTINGS_KEYS = [SETTINGS_KEYS.DOMAIN_ALERT_RULES] as const;
+
 /** All keys exposed to the system settings UI. */
-export const SYSTEM_SETTINGS_KEYS = [...SYSTEM_NOTIFICATION_SETTINGS_KEYS] as const;
+export const SYSTEM_SETTINGS_KEYS = [
+  ...SYSTEM_NOTIFICATION_SETTINGS_KEYS,
+  ...SYSTEM_SUBMISSION_SETTINGS_KEYS,
+] as const;

--- a/packages/ui/src/ToggleSwitch.tsx
+++ b/packages/ui/src/ToggleSwitch.tsx
@@ -1,12 +1,22 @@
-export interface ToggleSwitchProps {
+import type { ComponentPropsWithoutRef } from "react";
+
+export interface ToggleSwitchProps
+  extends Omit<ComponentPropsWithoutRef<"button">, "onChange" | "onClick"> {
   checked: boolean;
   onChange: (checked: boolean) => void;
   disabled?: boolean;
 }
 
-export function ToggleSwitch({ checked, onChange, disabled }: ToggleSwitchProps) {
+export function ToggleSwitch({
+  checked,
+  onChange,
+  disabled,
+  className,
+  ...buttonProps
+}: ToggleSwitchProps) {
   return (
     <button
+      {...buttonProps}
       type="button"
       role="switch"
       aria-checked={checked}
@@ -14,7 +24,7 @@ export function ToggleSwitch({ checked, onChange, disabled }: ToggleSwitchProps)
       onClick={() => onChange(!checked)}
       className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed ${
         checked ? "bg-[var(--color-primary)]" : "bg-[var(--ds-border-strong)]"
-      }`}
+      }${className ? ` ${className}` : ""}`}
     >
       <span
         className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${


### PR DESCRIPTION
## Summary
- replace the hardcoded Amazon submission gimmick with configurable domain alert rules
- add dashboard management for domain lists and markdown alert messages
- render configured public submission alerts in the suggestion form
- keep dashboard save actions scoped to their sections and support Cmd/Ctrl+S in the domain alert dialog

## Validation
- npm run lint
- npm run typecheck
- npm test --workspaces --if-present
- npm run ci:quality